### PR TITLE
Move .jean-claude directory inside ~/.claude

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jean-claude",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jean-claude",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -948,7 +948,6 @@
       "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -87,6 +87,6 @@ export const pushCommand = new Command('push')
       logger.success('Pushed to remote');
     } else if (!gitStatus.remote) {
       logger.warn('No remote configured - changes committed locally only');
-      logger.dim('Add a remote with: git -C ~/.jean-claude remote add origin <url>');
+      logger.dim(`Add a remote with: git -C ${formatPath(jeanClaudeDir)} remote add origin <url>`);
     }
   });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -105,7 +105,7 @@ export async function pull(dir: string): Promise<{ success: boolean; message: st
       throw new JeanClaudeError(
         'Merge conflict detected',
         ErrorCode.MERGE_CONFLICT,
-        'Resolve conflicts manually in ~/.jean-claude and try again.'
+        `Resolve conflicts manually in ${dir} and try again.`
       );
     }
     throw new JeanClaudeError(

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -17,7 +17,7 @@ export function detectPlatform(): 'darwin' | 'linux' {
 }
 
 export function getJeanClaudeDir(): string {
-  return path.join(os.homedir(), '.jean-claude');
+  return path.join(detectClaudeConfigDir(), '.jean-claude');
 }
 
 export function detectClaudeConfigDir(): string {


### PR DESCRIPTION
## Summary
- Relocates the jean-claude working directory from `~/.jean-claude` to `~/.claude/.jean-claude`
- Keeps all Claude-related files together and reduces dotfile clutter in the home directory
- Supports XDG config location (`~/.config/claude-code/.jean-claude`) automatically

## Migration
Existing users need to run:
```bash
mv ~/.jean-claude ~/.claude/.jean-claude
```

## Test plan
- [ ] Run `jean-claude init` on a fresh machine and verify it creates `~/.claude/.jean-claude`
- [ ] Verify `push` and `pull` commands work with the new location
- [ ] Verify error messages show the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)