### PR TITLE
Remove figlet dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "jean-claude",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jean-claude",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
-        "figlet": "^1.9.4",
         "fs-extra": "^11.2.0",
         "inquirer": "^9.2.0",
         "simple-git": "^3.22.0"
@@ -20,7 +19,6 @@
         "jean-claude": "dist/index.js"
       },
       "devDependencies": {
-        "@types/figlet": "^1.7.0",
         "@types/fs-extra": "^11.0.4",
         "@types/inquirer": "^9.0.7",
         "@types/node": "^20.11.0",
@@ -903,13 +901,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/figlet": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@types/figlet/-/figlet-1.7.0.tgz",
-      "integrity": "sha512-KwrT7p/8Eo3Op/HBSIwGXOsTZKYiM9NpWRBJ5sVjWP/SmlS+oxxRvJht/FNAtliJvja44N3ul1yATgohnVBV0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/fs-extra": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
@@ -948,7 +939,6 @@
       "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1490,30 +1480,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/figlet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.9.4.tgz",
-      "integrity": "sha512-uN6QE+TrzTAHC1IWTyrc4FfGo2KH/82J8Jl1tyKB7+z5DBit/m3D++Iu5lg91qJMnQQ3vpJrj5gxcK/pk4R9tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^14.0.0"
-      },
-      "bin": {
-        "figlet": "bin/index.js"
-      },
-      "engines": {
-        "node": ">= 17.0.0"
-      }
-    },
-    "node_modules/figlet/node_modules/commander": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -41,13 +41,11 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
-    "figlet": "^1.9.4",
     "fs-extra": "^11.2.0",
     "inquirer": "^9.2.0",
     "simple-git": "^3.22.0"
   },
   "devDependencies": {
-    "@types/figlet": "^1.7.0",
     "@types/fs-extra": "^11.0.4",
     "@types/inquirer": "^9.0.7",
     "@types/node": "^20.11.0",

--- a/src/utils/logo.ts
+++ b/src/utils/logo.ts
@@ -1,12 +1,9 @@
 import chalk from 'chalk';
-import figlet from 'figlet';
 
 export function printLogo(): void {
   const o = chalk.hex('#FF6B4A');
   const g = chalk.gray;
 
-  const text = figlet.textSync('JEAN-CLAUDE', { font: 'Small' });
-
-  console.log('\n' + o(text));
-  console.log(g('  A companion for syncing Claude Code configuration\n'));
+  console.log('\n' + o('JEAN-CLAUDE'));
+  console.log(g('A companion for syncing Claude Code configuration\n'));
 }


### PR DESCRIPTION
## Summary
- Remove `figlet` and `@types/figlet` dependencies
- Simplify logo display to plain colored text instead of ASCII art
- Reduces runtime dependencies from 6 to 5

## Test plan
- [x] Build passes (`npm run build`)
- [x] CLI works (`jean-claude --help` displays correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)