### PR TITLE
Add skills directory to sync configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Then you sit down at another machine and... nothing. Back to square one.
 - `CLAUDE.md` - Your custom instructions
 - `settings.json` - Your preferences
 - `hooks/` - Your automation scripts
+- `skills/` - Your custom skills
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jean-claude",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jean-claude",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -21,6 +21,11 @@ export const FILE_MAPPINGS: FileMapping[] = [
     target: 'hooks',
     type: 'directory',
   },
+  {
+    source: 'skills',
+    target: 'skills',
+    type: 'directory',
+  },
 ];
 
 function fileHash(filePath: string): string | null {


### PR DESCRIPTION
- Added skills/ directory to FILE_MAPPINGS in sync.ts
- Updated README.md to list skills as a synced resource
- Skills are now synced alongside hooks, CLAUDE.md, and settings.json