### PR TITLE
Add Claude Code plugin support

### DIFF
--- a/.claude-plugin/commands/init.md
+++ b/.claude-plugin/commands/init.md
@@ -1,0 +1,46 @@
+---
+name: init
+description: Initialize Jean-Claude and link to your config repository
+---
+
+# Jean-Claude Init
+
+Initialize Jean-Claude and link to your Claude Code configuration repository.
+
+## What This Does
+
+1. Sets up Jean-Claude for syncing your Claude Code configuration
+2. Links to a Git repository that will store your config
+3. Creates the initial sync structure
+
+## Usage
+
+Ask the user for their Git repository URL if they haven't provided it. The repository URL can be in any of these formats:
+- SSH: `git@github.com:username/repo.git`
+- HTTPS: `https://github.com/username/repo.git`
+- Other Git URLs
+
+Once you have the repository URL, run:
+
+```bash
+jean-claude init <repository-url>
+```
+
+## Example
+
+```bash
+jean-claude init git@github.com:username/jean-claude-config.git
+```
+
+## What Gets Synced
+
+- `CLAUDE.md` - Your custom instructions
+- `settings.json` - Your preferences
+- `hooks/` - Your automation scripts
+
+## After Initialization
+
+The user can now:
+- `jean-claude push` - Push local changes to the repo
+- `jean-claude pull` - Pull config from the repo
+- `jean-claude status` - Check sync status

--- a/.claude-plugin/commands/pull.md
+++ b/.claude-plugin/commands/pull.md
@@ -1,0 +1,42 @@
+---
+name: pull
+description: Pull configuration from the repository and apply it locally
+---
+
+# Jean-Claude Pull
+
+Pull the canonical Claude Code configuration from your Git repository and apply it to this machine.
+
+## What This Does
+
+1. Pulls the latest configuration from the remote repository
+2. Copies the configuration to `~/.claude`
+3. Applies the synced settings locally
+
+## Usage
+
+Simply run:
+
+```bash
+jean-claude pull
+```
+
+No arguments needed. The command will:
+- Fetch the latest changes from the remote repository
+- Copy `CLAUDE.md`, `settings.json`, and `hooks/` to `~/.claude`
+- Override local configuration with the canonical version
+
+## When to Use
+
+Use `jean-claude pull` when you:
+- Set up Claude Code on a new machine
+- Want to sync configuration changes from another machine
+- Need to reset your local config to the canonical version
+
+## Warning
+
+This will override your local `~/.claude` configuration with the version from the repository. Make sure to `jean-claude push` any local changes you want to keep first.
+
+## Check Before Pulling
+
+Run `jean-claude status` to see if there are uncommitted local changes before pulling.

--- a/.claude-plugin/commands/push.md
+++ b/.claude-plugin/commands/push.md
@@ -1,0 +1,39 @@
+---
+name: push
+description: Push local Claude Code configuration changes to the repository
+---
+
+# Jean-Claude Push
+
+Push your local Claude Code configuration changes to your Git repository.
+
+## What This Does
+
+1. Copies current configuration from `~/.claude` to the sync repository
+2. Commits the changes
+3. Pushes to the remote repository
+
+## Usage
+
+Simply run:
+
+```bash
+jean-claude push
+```
+
+No arguments needed. The command will:
+- Sync `CLAUDE.md`, `settings.json`, and `hooks/` from `~/.claude`
+- Create a commit with the changes
+- Push to the remote repository
+
+## When to Use
+
+Use `jean-claude push` when you've:
+- Updated your `CLAUDE.md` instructions
+- Changed settings in `settings.json`
+- Added or modified hooks
+- Made any configuration changes you want to sync to other machines
+
+## Next Steps
+
+After pushing, you can run `jean-claude pull` on other machines to sync the configuration.

--- a/.claude-plugin/commands/status.md
+++ b/.claude-plugin/commands/status.md
@@ -1,0 +1,43 @@
+---
+name: status
+description: Check whether this machine's configuration is in sync
+---
+
+# Jean-Claude Status
+
+Check whether this machine's Claude Code configuration is in sync with the repository.
+
+## What This Does
+
+1. Compares local `~/.claude` configuration with the sync repository
+2. Shows which files have been modified
+3. Indicates if you're ahead, behind, or in sync
+
+## Usage
+
+Simply run:
+
+```bash
+jean-claude status
+```
+
+No arguments needed. The command will show:
+- Files that have been modified locally
+- Whether local changes need to be pushed
+- Whether remote changes need to be pulled
+- Overall sync status
+
+## Example Output
+
+The status command will tell you:
+- ✓ In sync - Local and remote are identical
+- ⚠ Local changes - You have unpushed changes
+- ⚠ Remote changes - Remote has updates you don't have
+- ⚠ Diverged - Both local and remote have different changes
+
+## What to Do Next
+
+Based on the status:
+- If you have local changes: `jean-claude push`
+- If remote has changes: `jean-claude pull`
+- If diverged: Decide whether to push (override remote) or pull (override local)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "jean-claude-marketplace",
+  "description": "Claude Code configuration sync tools",
+  "version": "1.0.0",
+  "author": "Mike Veerman",
+  "plugins": [
+    {
+      "name": "jean-claude",
+      "source": ".",
+      "description": "Sync Claude Code configuration across machines using Git"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "jean-claude",
+  "version": "1.2.0",
+  "description": "Sync Claude Code configuration across machines using Git",
+  "author": "Mike Veerman",
+  "repository": "https://github.com/MikeVeerman/jean-claude",
+  "license": "MIT",
+  "engines": {
+    "claude": ">=0.1.0"
+  },
+  "keywords": [
+    "sync",
+    "configuration",
+    "dotfiles",
+    "git"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,27 @@ Then you sit down at another machine and... nothing. Back to square one.
 - `settings.json` - Your preferences
 - `hooks/` - Your automation scripts
 
-## Quick Start
+## Installation
+
+Choose your preferred method:
+
+### Option 1: Claude Code Plugin (Recommended for Claude Code users)
+
+```bash
+# Add the marketplace
+/plugin marketplace add MikeVeerman/jean-claude
+
+# Install the plugin
+/plugin install jean-claude
+
+# Use with natural language
+"Initialize jean-claude with my config repo at git@github.com:YOURUSER/jean-claude-config.git"
+"Push my Claude Code config"
+"Pull the latest config"
+"Check my sync status"
+```
+
+### Option 2: Standalone CLI (Works anywhere)
 
 ```bash
 # Install globally
@@ -25,6 +45,21 @@ npm install -g jean-claude
 # Verify install
 jean-claude --help
 
+# Use the CLI directly
+jean-claude init git@github.com:YOURUSER/jean-claude-config.git
+jean-claude push
+jean-claude pull
+jean-claude status
+```
+
+### Why Both?
+
+- **Claude Code Plugin**: Natural language interface, seamless integration, Claude can auto-sync
+- **Standalone CLI**: Works in CI/CD, scriptable, use outside Claude Code
+
+## Quick Start
+
+```bash
 # Initialize Jean-Claude and link to your config repo
 jean-claude init git@github.com:YOURUSER/jean-claude-config.git
 
@@ -41,6 +76,26 @@ jean-claude status
 ## That's it!
 
 Four commands. No options. No complexity. Just sync.
+
+## Plugin Architecture
+
+The Claude Code plugin is a thin wrapper that calls the npm package under the hood:
+
+```
+┌─────────────────────┐
+│  Claude Code Plugin │ ← Natural language interface
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│  jean-claude (npm)  │ ← Core functionality
+└─────────────────────┘
+```
+
+This means:
+- Updates to the npm package automatically benefit plugin users
+- Both distributions share the same battle-tested code
+- You can use whichever interface fits your workflow
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "files": [
     "dist",
-    "templates"
+    "templates",
+    ".claude-plugin"
   ],
   "dependencies": {
     "chalk": "^5.3.0",


### PR DESCRIPTION
Create plugin wrapper to offer jean-claude through Claude Code's plugin marketplace while maintaining the standalone npm package.

Changes:
- Add .claude-plugin/ directory with plugin manifest
- Create slash commands for init, push, pull, status
- Add marketplace.json for plugin distribution
- Update README with both installation methods
- Include .claude-plugin in npm package files

The plugin calls the npm CLI under the hood, allowing both distribution methods to coexist and share the same core functionality.