### PR TITLE
Make setup interactive and restructure syncing as a command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JEAN-CLAUDE
 
-**A companion for syncing Claude Code configuration across machines**
+**A companion for managing and syncing Claude Code configuration across machines**
 
 ## Why?
 
@@ -8,7 +8,7 @@ You've spent hours crafting the perfect `CLAUDE.md`. Your hooks are *chef's kiss
 
 Then you sit down at another machine and... nothing. Back to square one.
 
-**Jean-Claude fixes that.** It syncs your Claude Code configuration across all your machines using Git.
+**Jean-Claude fixes that.** It manages your Claude Code configuration with profiles and optional Git-based syncing across machines.
 
 ## What gets synced?
 
@@ -25,25 +25,27 @@ Then you sit down at another machine and... nothing. Back to square one.
 # Install globally
 npm install -g jean-claude
 
-# Verify install
-jean-claude --help
+# Initialize Jean-Claude
+jean-claude init
 
-# Initialize Jean-Claude and link to your config repo
-jean-claude init git@github.com:YOURUSER/jean-claude-config.git
+# (Optional) Set up Git-based syncing
+jean-claude sync setup
 
 # Make edits in ~/.claude, then push them
-jean-claude push
+jean-claude sync push
 
 # Pull the canonical config and apply it locally
-jean-claude pull
+jean-claude sync pull
 
 # Check whether this machine is in sync
-jean-claude status
+jean-claude sync status
 ```
 
 ## Profiles
 
 Got multiple Claude accounts? A Teams account for work and a Max account for personal projects? Jean-Claude can manage separate profiles for each, with shared configuration kept in sync via symlinks.
+
+Profiles work independently of syncing — you can use them without setting up Git.
 
 ```bash
 # Create a profile
@@ -80,11 +82,29 @@ Your main `~/.claude/` stays the source of truth. Profile directories are lightw
 
 Change a setting or add a hook in your main config, and all profiles see it immediately. Each profile gets its own `CLAUDE.md` for account-specific instructions.
 
-Profile definitions are stored in the Jean-Claude repo, so they sync across machines with `push` and `pull`.
+Profile definitions are stored in the Jean-Claude repo, so they sync across machines with `jean-claude sync push` and `jean-claude sync pull`.
+
+## Syncing
+
+Syncing is optional and uses Git to keep your configuration in sync across machines. Set it up at any time:
+
+```bash
+# Set up syncing with a Git remote
+jean-claude sync setup
+
+# Push your config
+jean-claude sync push
+
+# Pull on another machine
+jean-claude sync pull
+
+# Check sync status
+jean-claude sync status
+```
 
 ## That's it!
 
-Simple commands. No complexity. Just sync.
+Simple commands. No complexity. Profiles and sync.
 
 ## Development
 
@@ -119,10 +139,11 @@ Fast, isolated tests for core logic:
 #### Integration Tests
 
 End-to-end tests that simulate real usage with a local git repository and multiple machines:
-- **init command**: New repos, existing repos, already initialized, invalid remotes
-- **push command**: Initial files, no changes, modifications, new hooks
-- **pull command**: Basic sync, overwriting local changes, not initialized
-- **status command**: Clean state, uncommitted changes, not initialized
+- **init command**: New repos, existing repos, already initialized
+- **sync setup**: Linking to a Git remote
+- **sync push**: Initial files, no changes, modifications, new hooks
+- **sync pull**: Basic sync, overwriting local changes, not initialized
+- **sync status**: Clean state, uncommitted changes, not initialized
 - **Sync scenarios**: Bidirectional sync between machines
 - **Edge cases**: Empty directories, special characters, large files, multiple hooks, concurrent modifications, nested directories
 - **Metadata**: Persistence, timestamp updates

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import {
   pushCommand,
   statusCommand,
   profileCommand,
+  syncCommand,
 } from './commands/index.js';
 import { JeanClaudeError } from './types/index.js';
 import { printLogo } from './utils/logo.js';
@@ -19,7 +20,7 @@ export function createProgram(): Command {
 
   program
     .name('jean-claude')
-    .description('Sync Claude Code configuration across machines using Git')
+    .description('Manage and sync Claude Code configuration across machines')
     .version(VERSION)
     .addHelpText('before', () => {
       printLogo();
@@ -27,10 +28,13 @@ export function createProgram(): Command {
     });
 
   program.addCommand(initCommand);
+  program.addCommand(syncCommand);
+  program.addCommand(profileCommand);
+
+  // Deprecated — kept as hidden commands with redirect messages
   program.addCommand(pullCommand);
   program.addCommand(pushCommand);
   program.addCommand(statusCommand);
-  program.addCommand(profileCommand);
 
   return program;
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,3 +3,4 @@ export { pullCommand } from './pull.js';
 export { pushCommand } from './push.js';
 export { statusCommand } from './status.js';
 export { profileCommand } from './profile.js';
+export { syncCommand } from './sync.js';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,85 +1,68 @@
 import { Command } from 'commander';
 import fs from 'fs-extra';
+import path from 'path';
 import { logger, formatPath } from '../utils/logger.js';
-import { input } from '../utils/prompts.js';
+import { confirm } from '../utils/prompts.js';
 import { getConfigPaths, ensureDir } from '../lib/paths.js';
-import { isGitRepo, initRepo, addRemote, testRemoteConnection, cloneRepo } from '../lib/git.js';
 import {
   createMetaJson,
   writeMetaJson,
 } from '../lib/sync.js';
-import { JeanClaudeError, ErrorCode } from '../types/index.js';
+import { setupGitSync } from '../lib/sync-setup.js';
 import { printLogo } from '../utils/logo.js';
 
 export const initCommand = new Command('init')
   .description('Initialize Jean-Claude on this machine')
-  .action(async () => {
+  .option('--sync', 'Set up Git-based syncing (skip prompt)')
+  .option('--no-sync', 'Skip syncing setup (skip prompt)')
+  .action(async (options: { sync?: boolean }) => {
     const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
 
     printLogo();
     logger.heading('Setup');
 
     // Check if already initialized
-    if (fs.existsSync(jeanClaudeDir)) {
-      const isRepo = await isGitRepo(jeanClaudeDir);
-      if (isRepo) {
-        logger.success(`Already initialized at ${formatPath(jeanClaudeDir)}`);
-        logger.dim('Run "jean-claude status" to see current state.');
-        return;
-      }
-      throw new JeanClaudeError(
-        `${formatPath(jeanClaudeDir)} exists but is not a Git repository`,
-        ErrorCode.NOT_GIT_REPO,
-        'Remove the directory and run init again.'
-      );
+    const metaPath = path.join(jeanClaudeDir, 'meta.json');
+    if (fs.existsSync(metaPath)) {
+      logger.success(`Already initialized at ${formatPath(jeanClaudeDir)}`);
+      logger.dim('Run "jean-claude sync status" to see current state.');
+      return;
     }
 
-    // Explain what's needed
-    console.log('');
-    logger.dim('Paste the URL of your existing config repo, or create a new');
-    logger.dim('empty repo (e.g. "my-claude-config") on GitHub/GitLab.');
-    console.log('');
-
-    // Get repository URL
-    const repoUrl = await input('Repository URL:');
-
-    // Test connection to remote
-    logger.step(1, 3, 'Testing connection to repository...');
-    const canConnect = await testRemoteConnection(repoUrl);
-    if (!canConnect) {
-      throw new JeanClaudeError(
-        'Cannot connect to repository',
-        ErrorCode.NETWORK_ERROR,
-        'Check that the URL is correct and you have access.'
-      );
-    }
-    logger.success('Connection successful');
-
-    // Try to clone (will work if repo has content) or init fresh (if empty)
-    logger.step(2, 3, 'Setting up local repository...');
-    try {
-      await cloneRepo(repoUrl, jeanClaudeDir);
-      logger.success('Cloned existing config from repository');
-    } catch {
-      // Repo is empty, init locally and add remote
-      ensureDir(jeanClaudeDir);
-      await initRepo(jeanClaudeDir);
-      await addRemote(jeanClaudeDir, repoUrl);
-      logger.success('Initialized new repository');
-    }
-
-    // Create meta.json
+    // Create the jean-claude directory and meta.json
+    ensureDir(jeanClaudeDir);
     const meta = createMetaJson(claudeConfigDir);
     await writeMetaJson(jeanClaudeDir, meta);
 
+    // Ask about syncing (unless --sync or --no-sync was provided)
+    let wantSync: boolean;
+    if (options.sync !== undefined) {
+      wantSync = options.sync;
+    } else {
+      console.log('');
+      wantSync = await confirm('Would you like to set up syncing with a Git remote?');
+    }
+
+    if (wantSync) {
+      await setupGitSync(jeanClaudeDir);
+    }
+
     // Done
-    logger.step(3, 3, 'Done!');
     console.log('');
-    logger.success('Jean-Claude initialized!');
+    logger.success('Jean-Claude is installed!');
     console.log('');
     logger.dim('Next steps:');
-    logger.list([
-      'Run "jean-claude push" to push your config to Git',
-      'Run "jean-claude pull" on other machines to sync',
-    ]);
+
+    if (wantSync) {
+      logger.list([
+        'Run "jean-claude profile create <name>" to create a profile',
+        'Run "jean-claude sync push" to push your config to Git',
+        'Run "jean-claude sync pull" on other machines to sync',
+      ]);
+    } else {
+      logger.list([
+        'Run "jean-claude profile create <name>" to create a profile',
+        'Run "jean-claude sync setup" to configure syncing later',
+      ]);
+    }
   });

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -30,7 +30,7 @@ const profileCreateCommand = new Command('create')
       throw new JeanClaudeError(
         'Jean-Claude is not initialized',
         ErrorCode.NOT_INITIALIZED,
-        'Run `jean-claude init <repo-url>` first.'
+        'Run `jean-claude init` first.'
       );
     }
 

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,73 +1,17 @@
 import { Command } from 'commander';
-import fs from 'fs-extra';
 import chalk from 'chalk';
-import { logger, formatPath } from '../utils/logger.js';
-import { getConfigPaths } from '../lib/paths.js';
-import { isGitRepo, pull, getGitStatus, hasMergeConflicts, resetHard, cleanUntracked } from '../lib/git.js';
-import { syncToClaudeConfig, updateLastSync } from '../lib/sync.js';
-import { JeanClaudeError, ErrorCode } from '../types/index.js';
 
-export const pullCommand = new Command('pull')
-  .description('Pull latest config from Git and apply to Claude Code')
+const cmd = new Command('pull')
+  .description('(deprecated) Use "jean-claude sync pull" instead')
   .action(async () => {
-    const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
-
-    // Verify initialized
-    if (!fs.existsSync(jeanClaudeDir)) {
-      throw new JeanClaudeError(
-        'Jean-Claude is not initialized',
-        ErrorCode.NOT_INITIALIZED,
-        'Run "jean-claude init" first.'
-      );
-    }
-
-    if (!(await isGitRepo(jeanClaudeDir))) {
-      throw new JeanClaudeError(
-        `${formatPath(jeanClaudeDir)} is not a Git repository`,
-        ErrorCode.NOT_GIT_REPO,
-        'Run "jean-claude init" to set up properly.'
-      );
-    }
-
-    // Check if remote is configured
-    const gitStatus = await getGitStatus(jeanClaudeDir);
-    if (!gitStatus.remote) {
-      throw new JeanClaudeError(
-        'No remote configured',
-        ErrorCode.NO_REMOTE,
-        'Run "jean-claude init" to set up a remote repository.'
-      );
-    }
-
-    // Reset any local changes, clean untracked files, and pull
-    logger.step(1, 2, 'Pulling from Git...');
-    await resetHard(jeanClaudeDir);
-    await cleanUntracked(jeanClaudeDir);
-    const pullResult = await pull(jeanClaudeDir);
-    logger.success(pullResult.message);
-
-    // Check for merge conflicts (shouldn't happen after reset, but just in case)
-    if (await hasMergeConflicts(jeanClaudeDir)) {
-      throw new JeanClaudeError(
-        'Merge conflicts detected',
-        ErrorCode.MERGE_CONFLICT,
-        `Resolve conflicts in ${formatPath(jeanClaudeDir)} and run pull again.`
-      );
-    }
-
-    // Apply to ~/.claude
-    logger.step(2, 2, `Applying to ${formatPath(claudeConfigDir)}...`);
-    const results = await syncToClaudeConfig(jeanClaudeDir, claudeConfigDir);
-    const applied = results.filter((r) => r.action !== 'skipped');
-
-    // Update last sync time
-    await updateLastSync(jeanClaudeDir);
-
-    // Summary
-    console.log('');
-    logger.success(`Applied ${applied.length} file(s)`);
-    applied.forEach((r) => {
-      const icon = r.action === 'created' ? chalk.green('+') : chalk.yellow('~');
-      console.log(`  ${icon} ${r.file}`);
-    });
+    console.log(
+      chalk.yellow('This command has moved.') +
+      ' Did you mean ' +
+      chalk.cyan('jean-claude sync pull') +
+      '?'
+    );
+    process.exit(1);
   });
+
+(cmd as unknown as { _hidden: boolean })._hidden = true;
+export const pullCommand = cmd;

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,92 +1,17 @@
 import { Command } from 'commander';
-import fs from 'fs-extra';
-import os from 'os';
 import chalk from 'chalk';
-import { logger, formatPath } from '../utils/logger.js';
-import { getConfigPaths } from '../lib/paths.js';
-import { isGitRepo, getGitStatus, commitAndPush } from '../lib/git.js';
-import { updateLastSync, syncFromClaudeConfig } from '../lib/sync.js';
-import { JeanClaudeError, ErrorCode } from '../types/index.js';
 
-function generateCommitMessage(): string {
-  const hostname = os.hostname();
-  const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
-  return `Update from ${hostname} at ${timestamp}`;
-}
-
-export const pushCommand = new Command('push')
-  .description('Commit and push config changes to Git')
+const cmd = new Command('push')
+  .description('(deprecated) Use "jean-claude sync push" instead')
   .action(async () => {
-    const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
-
-    // Verify initialized
-    if (!fs.existsSync(jeanClaudeDir)) {
-      throw new JeanClaudeError(
-        'Jean-Claude is not initialized',
-        ErrorCode.NOT_INITIALIZED,
-        'Run "jean-claude init" first.'
-      );
-    }
-
-    if (!(await isGitRepo(jeanClaudeDir))) {
-      throw new JeanClaudeError(
-        `${formatPath(jeanClaudeDir)} is not a Git repository`,
-        ErrorCode.NOT_GIT_REPO,
-        'Run "jean-claude init" to set up properly.'
-      );
-    }
-
-    // Step 1: Copy files from ~/.claude to ~/.jean-claude
-    logger.step(1, 2, `Syncing from ${formatPath(claudeConfigDir)}...`);
-    const syncResults = await syncFromClaudeConfig(claudeConfigDir, jeanClaudeDir);
-    const synced = syncResults.filter((r) => r.action !== 'skipped');
-    if (synced.length > 0) {
-      synced.forEach((r) => {
-        console.log(`  ${chalk.blue('synced')}  ${r.file}`);
-      });
-    }
-
-    // Step 2: Check git status
-    const gitStatus = await getGitStatus(jeanClaudeDir);
-
-    if (gitStatus.isClean) {
-      logger.success('Nothing to push - everything is in sync.');
-      return;
-    }
-
-    // Show changes
-    logger.dim('Changes to push:');
-    if (gitStatus.modified.length > 0) {
-      gitStatus.modified.forEach((f) => {
-        console.log(`  ${chalk.yellow('modified')}  ${f}`);
-      });
-    }
-    if (gitStatus.untracked.length > 0) {
-      gitStatus.untracked.forEach((f) => {
-        console.log(`  ${chalk.green('new file')}  ${f}`);
-      });
-    }
-
-    // Commit message
-    const commitMessage = generateCommitMessage();
-
-    // Commit and push
-    logger.step(2, 2, 'Committing and pushing...');
-
-    const result = await commitAndPush(jeanClaudeDir, commitMessage, true);
-
-    // Update last sync
-    await updateLastSync(jeanClaudeDir);
-
-    // Summary
-    console.log('');
-    if (result.committed) {
-      logger.success('Changes committed');
-    }
-    if (result.pushed) {
-      logger.success('Pushed to remote');
-    } else if (!gitStatus.remote) {
-      logger.warn('No remote configured - changes committed locally only');
-      logger.dim(`Add a remote with: git -C ${formatPath(jeanClaudeDir)} remote add origin <url>`);
-    }
+    console.log(
+      chalk.yellow('This command has moved.') +
+      ' Did you mean ' +
+      chalk.cyan('jean-claude sync push') +
+      '?'
+    );
+    process.exit(1);
   });
+
+(cmd as unknown as { _hidden: boolean })._hidden = true;
+export const pushCommand = cmd;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,99 +1,17 @@
 import { Command } from 'commander';
-import fs from 'fs-extra';
 import chalk from 'chalk';
-import { logger, formatPath } from '../utils/logger.js';
-import { getConfigPaths } from '../lib/paths.js';
-import { isGitRepo, getGitStatus } from '../lib/git.js';
-import { compareFiles, readMetaJson } from '../lib/sync.js';
-import { JeanClaudeError, ErrorCode } from '../types/index.js';
 
-export const statusCommand = new Command('status')
-  .description('Show sync status')
+const cmd = new Command('status')
+  .description('(deprecated) Use "jean-claude sync status" instead')
   .action(async () => {
-    const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
-
-    // Verify initialized
-    if (!fs.existsSync(jeanClaudeDir)) {
-      throw new JeanClaudeError(
-        'Jean-Claude is not initialized',
-        ErrorCode.NOT_INITIALIZED,
-        'Run "jean-claude init" first.'
-      );
-    }
-
-    const isRepo = await isGitRepo(jeanClaudeDir);
-    const gitStatus = isRepo ? await getGitStatus(jeanClaudeDir) : null;
-    const meta = await readMetaJson(jeanClaudeDir);
-    const fileComparison = compareFiles(jeanClaudeDir, claudeConfigDir);
-
-    // Pretty output
-    logger.heading('Jean-Claude Status');
-
-    console.log('');
-    logger.table([
-      ['Repository', formatPath(jeanClaudeDir)],
-      ['Claude Config', formatPath(claudeConfigDir)],
-      ['Platform', meta?.platform || 'unknown'],
-    ]);
-
-    // Git status
-    console.log('');
-    logger.dim('Git Status');
-    if (!isRepo) {
-      console.log(`  ${chalk.red('✗')} Not a Git repository`);
-    } else if (gitStatus) {
-      console.log(
-        `  ${chalk.dim('Branch:')}  ${gitStatus.branch || 'unknown'}`
-      );
-      console.log(
-        `  ${chalk.dim('Remote:')}  ${gitStatus.remote || chalk.yellow('none')}`
-      );
-
-      if (gitStatus.isClean) {
-        console.log(`  ${chalk.green('✓')} Working tree clean`);
-      } else {
-        console.log(
-          `  ${chalk.yellow('!')} ${gitStatus.modified.length + gitStatus.untracked.length} uncommitted change(s)`
-        );
-      }
-
-      if (gitStatus.ahead > 0) {
-        console.log(`  ${chalk.blue('↑')} ${gitStatus.ahead} commit(s) ahead`);
-      }
-      if (gitStatus.behind > 0) {
-        console.log(`  ${chalk.yellow('↓')} ${gitStatus.behind} commit(s) behind`);
-      }
-    }
-
-    // File sync status
-    console.log('');
-    logger.dim('Sync Status');
-    fileComparison.forEach((c) => {
-      let status: string;
-      let icon: string;
-
-      if (!c.sourceExists) {
-        status = chalk.dim('not configured');
-        icon = chalk.dim('-');
-      } else if (!c.targetExists) {
-        status = chalk.yellow('not applied');
-        icon = chalk.yellow('!');
-      } else if (c.inSync) {
-        status = chalk.green('in sync');
-        icon = chalk.green('✓');
-      } else {
-        status = chalk.yellow('differs');
-        icon = chalk.yellow('!');
-      }
-
-      console.log(
-        `  ${icon} ${c.mapping.source.padEnd(15)} ${chalk.dim('→')} ${c.mapping.target.padEnd(15)} ${status}`
-      );
-    });
-
-    // Last sync
-    if (meta?.lastSync) {
-      console.log('');
-      logger.dim(`Last sync: ${new Date(meta.lastSync).toLocaleString()}`);
-    }
+    console.log(
+      chalk.yellow('This command has moved.') +
+      ' Did you mean ' +
+      chalk.cyan('jean-claude sync status') +
+      '?'
+    );
+    process.exit(1);
   });
+
+(cmd as unknown as { _hidden: boolean })._hidden = true;
+export const statusCommand = cmd;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,0 +1,280 @@
+import { Command } from 'commander';
+import fs from 'fs-extra';
+import os from 'os';
+import chalk from 'chalk';
+import { logger, formatPath } from '../utils/logger.js';
+import { getConfigPaths } from '../lib/paths.js';
+import { isGitRepo, getGitStatus, commitAndPush, pull, hasMergeConflicts, resetHard, cleanUntracked } from '../lib/git.js';
+import { syncFromClaudeConfig, syncToClaudeConfig, updateLastSync, compareFiles, readMetaJson } from '../lib/sync.js';
+import { setupGitSync } from '../lib/sync-setup.js';
+import { JeanClaudeError, ErrorCode } from '../types/index.js';
+
+function generateCommitMessage(): string {
+  const hostname = os.hostname();
+  const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  return `Update from ${hostname} at ${timestamp}`;
+}
+
+const syncSetupCommand = new Command('setup')
+  .description('Set up Git-based syncing for your configuration')
+  .action(async () => {
+    const { jeanClaudeDir } = getConfigPaths();
+
+    if (!fs.existsSync(jeanClaudeDir)) {
+      throw new JeanClaudeError(
+        'Jean-Claude is not initialized',
+        ErrorCode.NOT_INITIALIZED,
+        'Run "jean-claude init" first.'
+      );
+    }
+
+    await setupGitSync(jeanClaudeDir);
+
+    console.log('');
+    logger.dim('Next steps:');
+    logger.list([
+      'Run "jean-claude sync push" to push your config to Git',
+      'Run "jean-claude sync pull" on other machines to sync',
+    ]);
+  });
+
+const syncPushCommand = new Command('push')
+  .description('Commit and push config changes to Git')
+  .action(async () => {
+    const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
+
+    // Verify initialized
+    if (!fs.existsSync(jeanClaudeDir)) {
+      throw new JeanClaudeError(
+        'Jean-Claude is not initialized',
+        ErrorCode.NOT_INITIALIZED,
+        'Run "jean-claude init" first.'
+      );
+    }
+
+    if (!(await isGitRepo(jeanClaudeDir))) {
+      throw new JeanClaudeError(
+        `${formatPath(jeanClaudeDir)} is not a Git repository`,
+        ErrorCode.NOT_GIT_REPO,
+        'Run "jean-claude sync setup" to configure syncing.'
+      );
+    }
+
+    // Step 1: Copy files from ~/.claude to ~/.jean-claude
+    logger.step(1, 2, `Syncing from ${formatPath(claudeConfigDir)}...`);
+    const syncResults = await syncFromClaudeConfig(claudeConfigDir, jeanClaudeDir);
+    const synced = syncResults.filter((r) => r.action !== 'skipped');
+    if (synced.length > 0) {
+      synced.forEach((r) => {
+        console.log(`  ${chalk.blue('synced')}  ${r.file}`);
+      });
+    }
+
+    // Step 2: Check git status
+    const gitStatus = await getGitStatus(jeanClaudeDir);
+
+    if (gitStatus.isClean) {
+      logger.success('Nothing to push - everything is in sync.');
+      return;
+    }
+
+    // Show changes
+    logger.dim('Changes to push:');
+    if (gitStatus.modified.length > 0) {
+      gitStatus.modified.forEach((f) => {
+        console.log(`  ${chalk.yellow('modified')}  ${f}`);
+      });
+    }
+    if (gitStatus.untracked.length > 0) {
+      gitStatus.untracked.forEach((f) => {
+        console.log(`  ${chalk.green('new file')}  ${f}`);
+      });
+    }
+
+    // Commit message
+    const commitMessage = generateCommitMessage();
+
+    // Commit and push
+    logger.step(2, 2, 'Committing and pushing...');
+
+    const result = await commitAndPush(jeanClaudeDir, commitMessage, true);
+
+    // Update last sync
+    await updateLastSync(jeanClaudeDir);
+
+    // Summary
+    console.log('');
+    if (result.committed) {
+      logger.success('Changes committed');
+    }
+    if (result.pushed) {
+      logger.success('Pushed to remote');
+    } else if (!gitStatus.remote) {
+      logger.warn('No remote configured - changes committed locally only');
+      logger.dim(`Add a remote with: git -C ${formatPath(jeanClaudeDir)} remote add origin <url>`);
+    }
+  });
+
+const syncPullCommand = new Command('pull')
+  .description('Pull latest config from Git and apply to Claude Code')
+  .action(async () => {
+    const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
+
+    // Verify initialized
+    if (!fs.existsSync(jeanClaudeDir)) {
+      throw new JeanClaudeError(
+        'Jean-Claude is not initialized',
+        ErrorCode.NOT_INITIALIZED,
+        'Run "jean-claude init" first.'
+      );
+    }
+
+    if (!(await isGitRepo(jeanClaudeDir))) {
+      throw new JeanClaudeError(
+        `${formatPath(jeanClaudeDir)} is not a Git repository`,
+        ErrorCode.NOT_GIT_REPO,
+        'Run "jean-claude sync setup" to configure syncing.'
+      );
+    }
+
+    // Check if remote is configured
+    const gitStatus = await getGitStatus(jeanClaudeDir);
+    if (!gitStatus.remote) {
+      throw new JeanClaudeError(
+        'No remote configured',
+        ErrorCode.NO_REMOTE,
+        'Run "jean-claude sync setup" to set up a remote repository.'
+      );
+    }
+
+    // Reset any local changes, clean untracked files, and pull
+    logger.step(1, 2, 'Pulling from Git...');
+    await resetHard(jeanClaudeDir);
+    await cleanUntracked(jeanClaudeDir);
+    const pullResult = await pull(jeanClaudeDir);
+    logger.success(pullResult.message);
+
+    // Check for merge conflicts (shouldn't happen after reset, but just in case)
+    if (await hasMergeConflicts(jeanClaudeDir)) {
+      throw new JeanClaudeError(
+        'Merge conflicts detected',
+        ErrorCode.MERGE_CONFLICT,
+        `Resolve conflicts in ${formatPath(jeanClaudeDir)} and run pull again.`
+      );
+    }
+
+    // Apply to ~/.claude
+    logger.step(2, 2, `Applying to ${formatPath(claudeConfigDir)}...`);
+    const results = await syncToClaudeConfig(jeanClaudeDir, claudeConfigDir);
+    const applied = results.filter((r) => r.action !== 'skipped');
+
+    // Update last sync time
+    await updateLastSync(jeanClaudeDir);
+
+    // Summary
+    console.log('');
+    logger.success(`Applied ${applied.length} file(s)`);
+    applied.forEach((r) => {
+      const icon = r.action === 'created' ? chalk.green('+') : chalk.yellow('~');
+      console.log(`  ${icon} ${r.file}`);
+    });
+  });
+
+const syncStatusCommand = new Command('status')
+  .description('Show sync status')
+  .action(async () => {
+    const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
+
+    // Verify initialized
+    if (!fs.existsSync(jeanClaudeDir)) {
+      throw new JeanClaudeError(
+        'Jean-Claude is not initialized',
+        ErrorCode.NOT_INITIALIZED,
+        'Run "jean-claude init" first.'
+      );
+    }
+
+    const isRepo = await isGitRepo(jeanClaudeDir);
+    const gitStatus = isRepo ? await getGitStatus(jeanClaudeDir) : null;
+    const meta = await readMetaJson(jeanClaudeDir);
+    const fileComparison = compareFiles(jeanClaudeDir, claudeConfigDir);
+
+    // Pretty output
+    logger.heading('Jean-Claude Status');
+
+    console.log('');
+    logger.table([
+      ['Repository', formatPath(jeanClaudeDir)],
+      ['Claude Config', formatPath(claudeConfigDir)],
+      ['Platform', meta?.platform || 'unknown'],
+    ]);
+
+    // Git status
+    console.log('');
+    logger.dim('Git Status');
+    if (!isRepo) {
+      console.log(`  ${chalk.red('✗')} Not a Git repository`);
+      logger.dim('  Run "jean-claude sync setup" to enable syncing.');
+    } else if (gitStatus) {
+      console.log(
+        `  ${chalk.dim('Branch:')}  ${gitStatus.branch || 'unknown'}`
+      );
+      console.log(
+        `  ${chalk.dim('Remote:')}  ${gitStatus.remote || chalk.yellow('none')}`
+      );
+
+      if (gitStatus.isClean) {
+        console.log(`  ${chalk.green('✓')} Working tree clean`);
+      } else {
+        console.log(
+          `  ${chalk.yellow('!')} ${gitStatus.modified.length + gitStatus.untracked.length} uncommitted change(s)`
+        );
+      }
+
+      if (gitStatus.ahead > 0) {
+        console.log(`  ${chalk.blue('↑')} ${gitStatus.ahead} commit(s) ahead`);
+      }
+      if (gitStatus.behind > 0) {
+        console.log(`  ${chalk.yellow('↓')} ${gitStatus.behind} commit(s) behind`);
+      }
+    }
+
+    // File sync status
+    console.log('');
+    logger.dim('Sync Status');
+    fileComparison.forEach((c) => {
+      let status: string;
+      let icon: string;
+
+      if (!c.sourceExists) {
+        status = chalk.dim('not configured');
+        icon = chalk.dim('-');
+      } else if (!c.targetExists) {
+        status = chalk.yellow('not applied');
+        icon = chalk.yellow('!');
+      } else if (c.inSync) {
+        status = chalk.green('in sync');
+        icon = chalk.green('✓');
+      } else {
+        status = chalk.yellow('differs');
+        icon = chalk.yellow('!');
+      }
+
+      console.log(
+        `  ${icon} ${c.mapping.source.padEnd(15)} ${chalk.dim('→')} ${c.mapping.target.padEnd(15)} ${status}`
+      );
+    });
+
+    // Last sync
+    if (meta?.lastSync) {
+      console.log('');
+      logger.dim(`Last sync: ${new Date(meta.lastSync).toLocaleString()}`);
+    }
+  });
+
+export const syncCommand = new Command('sync')
+  .description('Manage Git-based syncing of your configuration')
+  .addCommand(syncSetupCommand)
+  .addCommand(syncPushCommand)
+  .addCommand(syncPullCommand)
+  .addCommand(syncStatusCommand);

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -144,7 +144,8 @@ export async function commitAndPush(
     const remotes = await git.getRemotes();
     if (remotes.length > 0) {
       try {
-        await git.push();
+        // Use -u to set upstream on first push
+        await git.push(['-u', 'origin', 'HEAD']);
         return { committed: true, pushed: true };
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/lib/sync-setup.ts
+++ b/src/lib/sync-setup.ts
@@ -1,0 +1,89 @@
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { logger } from '../utils/logger.js';
+import { input } from '../utils/prompts.js';
+import { isGitRepo, createGit, initRepo, addRemote, testRemoteConnection, cloneRepo } from './git.js';
+import { JeanClaudeError, ErrorCode } from '../types/index.js';
+
+/**
+ * Interactive Git remote setup flow.
+ * Used by both `jean-claude init` (when user opts in) and `jean-claude sync setup`.
+ */
+export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
+  const isRepo = await isGitRepo(jeanClaudeDir);
+
+  if (isRepo) {
+    // Already a git repo — check if remote is configured
+    const git = createGit(jeanClaudeDir);
+    const remotes = await git.getRemotes();
+    if (remotes.length > 0) {
+      logger.success('Syncing is already configured.');
+      return;
+    }
+  }
+
+  // Explain what's needed
+  console.log('');
+  logger.dim('Paste the URL of your existing config repo, or create a new');
+  logger.dim('empty repo (e.g. "my-claude-config") on GitHub/GitLab.');
+  console.log('');
+
+  // Get repository URL
+  const repoUrl = await input('Repository URL:');
+
+  // Test connection to remote
+  logger.step(1, 2, 'Testing connection to repository...');
+  const canConnect = await testRemoteConnection(repoUrl);
+  if (!canConnect) {
+    throw new JeanClaudeError(
+      'Cannot connect to repository',
+      ErrorCode.NETWORK_ERROR,
+      'Check that the URL is correct and you have access.'
+    );
+  }
+  logger.success('Connection successful');
+
+  // Set up the git repo
+  logger.step(2, 2, 'Setting up local repository...');
+
+  if (isRepo) {
+    // Already a git repo but no remote — just add the remote
+    await addRemote(jeanClaudeDir, repoUrl);
+    logger.success('Remote added to existing repository');
+  } else {
+    // Not a git repo — need to set up git
+    const dirContents = await fs.readdir(jeanClaudeDir);
+
+    if (dirContents.length === 0) {
+      // Empty directory — clone directly
+      try {
+        await cloneRepo(repoUrl, jeanClaudeDir);
+        logger.success('Cloned existing config from repository');
+      } catch {
+        await initRepo(jeanClaudeDir);
+        await addRemote(jeanClaudeDir, repoUrl);
+        logger.success('Initialized new repository');
+      }
+    } else {
+      // Non-empty directory (e.g. has meta.json) — clone to temp, move .git over
+      const tmpDir = path.join(os.tmpdir(), `jean-claude-clone-${Date.now()}`);
+      try {
+        await cloneRepo(repoUrl, tmpDir);
+        // Move .git from clone into our directory
+        await fs.move(path.join(tmpDir, '.git'), path.join(jeanClaudeDir, '.git'));
+        // Reset to match working tree (our existing files take priority)
+        const git = createGit(jeanClaudeDir);
+        await git.reset(['HEAD']);
+        logger.success('Cloned existing config from repository');
+      } catch {
+        // Remote is empty — just init locally
+        await initRepo(jeanClaudeDir);
+        await addRemote(jeanClaudeDir, repoUrl);
+        logger.success('Initialized new repository');
+      } finally {
+        await fs.remove(tmpDir);
+      }
+    }
+  }
+}

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -4,10 +4,11 @@
 # This script sets up a local git repo and tests jean-claude's functionality and edge cases
 #
 # The script tests:
-# - init command (new repos, existing repos, already initialized, invalid remotes)
-# - push command (initial files, no changes, modifications, new hooks)
-# - pull command (basic sync, overwriting local changes, not initialized)
-# - status command (clean state, uncommitted changes, not initialized)
+# - init command (new repos, existing repos, already initialized)
+# - sync setup command (linking to a Git remote)
+# - sync push command (initial files, no changes, modifications, new hooks)
+# - sync pull command (basic sync, overwriting local changes, not initialized)
+# - sync status command (clean state, uncommitted changes, not initialized)
 # - Sync scenarios (bidirectional sync between machines)
 # - Multi-repo sync (3 machines: chain sync, convergence, concurrent modifications, hooks/skills sync, late joiner)
 # - Edge cases (empty directories, special characters, large files, multiple hooks, concurrent modifications, nested directories)
@@ -183,8 +184,8 @@ run_jean_claude() {
 test_init_new_repo() {
     print_test "init command with new repository"
 
-    # Simulate user input for init command
-    echo "$REMOTE_REPO" | run_jean_claude "$MACHINE1_DIR" init
+    # Simulate user input for init command (--sync flag + repo URL via stdin)
+    echo "$REMOTE_REPO" | run_jean_claude "$MACHINE1_DIR" init --sync
 
     assert_dir_exists "$MACHINE1_DIR/.claude/.jean-claude"
     assert_dir_exists "$MACHINE1_DIR/.claude/.jean-claude/.git"
@@ -200,7 +201,7 @@ test_init_already_initialized() {
     print_test "init command when already initialized"
 
     # Should detect and report that it's already initialized
-    if echo "$REMOTE_REPO" | run_jean_claude "$MACHINE1_DIR" init 2>&1 | grep -q "Already initialized"; then
+    if run_jean_claude "$MACHINE1_DIR" init 2>&1 | grep -q "Already initialized"; then
         print_success "Correctly detected already initialized"
     else
         print_failure "Did not detect already initialized state"
@@ -211,7 +212,7 @@ test_init_with_existing_repo() {
     print_test "init command with existing remote repository"
 
     # Machine 2 should clone the existing repo created by machine 1
-    echo "$REMOTE_REPO" | run_jean_claude "$MACHINE2_DIR" init
+    echo "$REMOTE_REPO" | run_jean_claude "$MACHINE2_DIR" init --sync
 
     assert_dir_exists "$MACHINE2_DIR/.claude/.jean-claude"
     assert_file_exists "$MACHINE2_DIR/.claude/.jean-claude/meta.json"
@@ -220,11 +221,11 @@ test_init_with_existing_repo() {
 test_init_invalid_remote() {
     print_test "init command with invalid remote URL"
 
-    MACHINE3_DIR="$TEST_DIR/machine3"
-    mkdir -p "$MACHINE3_DIR/.claude"
+    INVALID_MACHINE_DIR="$TEST_DIR/machine-invalid"
+    mkdir -p "$INVALID_MACHINE_DIR/.claude"
 
     # Should fail with invalid remote
-    if echo "/invalid/repo/path" | run_jean_claude "$MACHINE3_DIR" init 2>&1; then
+    if echo "/invalid/repo/path" | run_jean_claude "$INVALID_MACHINE_DIR" init --sync 2>&1; then
         print_failure "Should have failed with invalid remote"
     else
         print_success "Correctly failed with invalid remote"
@@ -243,7 +244,7 @@ test_push_initial_files() {
     chmod +x "$MACHINE1_DIR/.claude/hooks/test-hook.sh"
 
     # Push the files
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Verify files are in the jean-claude repo
     assert_file_exists "$MACHINE1_DIR/.claude/.jean-claude/CLAUDE.md"
@@ -264,7 +265,7 @@ test_push_no_changes() {
     print_test "push command with no changes"
 
     # Push again without changes
-    if run_jean_claude "$MACHINE1_DIR" push 2>&1 | grep -q "No changes"; then
+    if run_jean_claude "$MACHINE1_DIR" sync push 2>&1 | grep -q "No changes"; then
         print_success "Correctly detected no changes"
     else
         # It's okay if it just completes without error
@@ -278,7 +279,7 @@ test_push_modified_files() {
     # Modify a file
     echo "# Updated Custom Instructions" > "$MACHINE1_DIR/.claude/CLAUDE.md"
 
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Verify the change is in the repo
     if grep -q "Updated Custom Instructions" "$MACHINE1_DIR/.claude/.jean-claude/CLAUDE.md"; then
@@ -295,7 +296,7 @@ test_push_new_hook() {
     echo "#!/bin/bash\necho 'new hook'" > "$MACHINE1_DIR/.claude/hooks/new-hook.sh"
     chmod +x "$MACHINE1_DIR/.claude/hooks/new-hook.sh"
 
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     assert_file_exists "$MACHINE1_DIR/.claude/.jean-claude/hooks/new-hook.sh"
 }
@@ -305,7 +306,7 @@ test_pull_basic() {
     print_test "pull command to sync files"
 
     # Pull on machine2 should get the files from machine1
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
 
     assert_file_exists "$MACHINE2_DIR/.claude/CLAUDE.md"
     assert_file_exists "$MACHINE2_DIR/.claude/settings.json"
@@ -327,7 +328,7 @@ test_pull_overwrites_local() {
     echo "# Local changes" > "$MACHINE2_DIR/.claude/CLAUDE.md"
 
     # Pull should overwrite
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
 
     if grep -q "Updated Custom Instructions" "$MACHINE2_DIR/.claude/CLAUDE.md"; then
         print_success "Local changes overwritten by pull"
@@ -342,7 +343,7 @@ test_pull_not_initialized() {
     MACHINE4_DIR="$TEST_DIR/machine4"
     mkdir -p "$MACHINE4_DIR/.claude"
 
-    if run_jean_claude "$MACHINE4_DIR" pull 2>&1 | grep -q "not initialized"; then
+    if run_jean_claude "$MACHINE4_DIR" sync pull 2>&1 | grep -q "not initialized"; then
         print_success "Correctly detected not initialized"
     else
         print_failure "Did not detect not initialized state"
@@ -353,7 +354,7 @@ test_pull_not_initialized() {
 test_status_clean() {
     print_test "status command with clean state"
 
-    output=$(run_jean_claude "$MACHINE1_DIR" status 2>&1 || true)
+    output=$(run_jean_claude "$MACHINE1_DIR" sync status 2>&1 || true)
 
     if echo "$output" | grep -q "Status"; then
         print_success "Status command executed"
@@ -368,7 +369,7 @@ test_status_with_changes() {
     # Make a change without pushing
     echo '{"theme": "light"}' > "$MACHINE1_DIR/.claude/settings.json"
 
-    output=$(run_jean_claude "$MACHINE1_DIR" status 2>&1 || true)
+    output=$(run_jean_claude "$MACHINE1_DIR" sync status 2>&1 || true)
 
     if echo "$output" | grep -q "settings.json"; then
         print_success "Status shows changed file"
@@ -383,7 +384,7 @@ test_status_not_initialized() {
     MACHINE5_DIR="$TEST_DIR/machine5"
     mkdir -p "$MACHINE5_DIR/.claude"
 
-    if run_jean_claude "$MACHINE5_DIR" status 2>&1 | grep -q "not initialized"; then
+    if run_jean_claude "$MACHINE5_DIR" sync status 2>&1 | grep -q "not initialized"; then
         print_success "Correctly detected not initialized"
     else
         print_failure "Did not detect not initialized state"
@@ -395,10 +396,10 @@ test_bidirectional_sync() {
     print_test "bidirectional sync between machines"
 
     # Push the light theme from machine1
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Pull on machine2
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
 
     # Verify machine2 has the light theme
     if grep -q "light" "$MACHINE2_DIR/.claude/settings.json"; then
@@ -412,10 +413,10 @@ test_bidirectional_sync() {
     echo "#!/bin/bash\necho 'from machine2'" > "$MACHINE2_DIR/.claude/hooks/machine2-hook.sh"
     chmod +x "$MACHINE2_DIR/.claude/hooks/machine2-hook.sh"
 
-    run_jean_claude "$MACHINE2_DIR" push
+    run_jean_claude "$MACHINE2_DIR" sync push
 
     # Pull on machine1
-    run_jean_claude "$MACHINE1_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
 
     # Verify machine1 has the new hook
     assert_file_exists "$MACHINE1_DIR/.claude/hooks/machine2-hook.sh"
@@ -426,7 +427,7 @@ test_three_machine_init() {
     print_test "initialize third machine from existing remote"
 
     # Machine 3 initializes from the same remote
-    echo "$REMOTE_REPO" | run_jean_claude "$MACHINE3_DIR" init
+    echo "$REMOTE_REPO" | run_jean_claude "$MACHINE3_DIR" init --sync
 
     assert_dir_exists "$MACHINE3_DIR/.claude/.jean-claude"
     assert_file_exists "$MACHINE3_DIR/.claude/.jean-claude/meta.json"
@@ -449,14 +450,14 @@ test_three_machine_chain_sync() {
     # Machine 1 creates a unique file in skills (which is synced)
     mkdir -p "$MACHINE1_DIR/.claude/skills"
     echo "# Created on Machine 1 for chain sync test" > "$MACHINE1_DIR/.claude/skills/chain-test.md"
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Machine 2 pulls and verifies
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
     assert_file_exists "$MACHINE2_DIR/.claude/skills/chain-test.md"
 
     # Machine 3 pulls and verifies
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
     assert_file_exists "$MACHINE3_DIR/.claude/skills/chain-test.md"
 
     # Verify content is the same across all machines
@@ -473,22 +474,22 @@ test_three_machine_convergence() {
     # Machine 1 creates and pushes its file in skills (which is synced)
     mkdir -p "$MACHINE1_DIR/.claude/skills"
     echo "# File from Machine 1" > "$MACHINE1_DIR/.claude/skills/from-m1.md"
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Machine 2 pulls (gets m1's file), creates its own file, then pushes
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
     echo "# File from Machine 2" > "$MACHINE2_DIR/.claude/skills/from-m2.md"
-    run_jean_claude "$MACHINE2_DIR" push
+    run_jean_claude "$MACHINE2_DIR" sync push
 
     # Machine 3 pulls (gets m1 and m2's files), creates its own file, then pushes
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
     echo "# File from Machine 3" > "$MACHINE3_DIR/.claude/skills/from-m3.md"
-    run_jean_claude "$MACHINE3_DIR" push
+    run_jean_claude "$MACHINE3_DIR" sync push
 
     # Final pull on all machines to converge
-    run_jean_claude "$MACHINE1_DIR" pull
-    run_jean_claude "$MACHINE2_DIR" pull
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
 
     # Verify all machines have all 3 files
     local all_synced=true
@@ -512,22 +513,22 @@ test_three_machine_sequential_modifications() {
     # Start with a shared file in skills (which is synced)
     mkdir -p "$MACHINE1_DIR/.claude/skills"
     echo "Version 1: From Machine 1" > "$MACHINE1_DIR/.claude/skills/shared-doc.md"
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Machine 2 pulls, modifies, and pushes
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
     echo "Version 2: Modified by Machine 2" > "$MACHINE2_DIR/.claude/skills/shared-doc.md"
-    run_jean_claude "$MACHINE2_DIR" push
+    run_jean_claude "$MACHINE2_DIR" sync push
 
     # Machine 3 pulls, modifies, and pushes
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
     echo "Version 3: Modified by Machine 3" > "$MACHINE3_DIR/.claude/skills/shared-doc.md"
-    run_jean_claude "$MACHINE3_DIR" push
+    run_jean_claude "$MACHINE3_DIR" sync push
 
     # All machines pull the latest
-    run_jean_claude "$MACHINE1_DIR" pull
-    run_jean_claude "$MACHINE2_DIR" pull
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
 
     # Verify all machines have the final version
     local all_have_v3=true
@@ -547,29 +548,29 @@ test_three_machine_concurrent_different_files() {
     print_test "concurrent modifications to different files from 3 machines"
 
     # Pull latest state first to start clean
-    run_jean_claude "$MACHINE1_DIR" pull
-    run_jean_claude "$MACHINE2_DIR" pull
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
 
     # Machine 1 creates its file in skills and pushes
     mkdir -p "$MACHINE1_DIR/.claude/skills"
     echo "# Concurrent edit from M1" > "$MACHINE1_DIR/.claude/skills/concurrent-m1.md"
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Machine 2 pulls (gets m1's file), creates its file, pushes
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
     echo "# Concurrent edit from M2" > "$MACHINE2_DIR/.claude/skills/concurrent-m2.md"
-    run_jean_claude "$MACHINE2_DIR" push
+    run_jean_claude "$MACHINE2_DIR" sync push
 
     # Machine 3 pulls (gets m1 and m2's files), creates its file, pushes
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
     echo "# Concurrent edit from M3" > "$MACHINE3_DIR/.claude/skills/concurrent-m3.md"
-    run_jean_claude "$MACHINE3_DIR" push
+    run_jean_claude "$MACHINE3_DIR" sync push
 
     # Final sync - all machines pull
-    run_jean_claude "$MACHINE1_DIR" pull
-    run_jean_claude "$MACHINE2_DIR" pull
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
 
     # Check that all 3 files exist on all machines
     local all_files_present=true
@@ -594,22 +595,22 @@ test_three_machine_hooks_sync() {
     # Machine 1 creates hooks
     mkdir -p "$MACHINE1_DIR/.claude/hooks"
     echo "#!/bin/bash\necho 'hook from m1'" > "$MACHINE1_DIR/.claude/hooks/m1-hook.sh"
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Machine 2 creates additional hooks
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
     echo "#!/bin/bash\necho 'hook from m2'" > "$MACHINE2_DIR/.claude/hooks/m2-hook.sh"
-    run_jean_claude "$MACHINE2_DIR" push
+    run_jean_claude "$MACHINE2_DIR" sync push
 
     # Machine 3 creates additional hooks
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
     echo "#!/bin/bash\necho 'hook from m3'" > "$MACHINE3_DIR/.claude/hooks/m3-hook.sh"
-    run_jean_claude "$MACHINE3_DIR" push
+    run_jean_claude "$MACHINE3_DIR" sync push
 
     # Final pull on all machines
-    run_jean_claude "$MACHINE1_DIR" pull
-    run_jean_claude "$MACHINE2_DIR" pull
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
 
     # Verify all machines have all hooks
     local all_hooks_present=true
@@ -633,23 +634,23 @@ test_three_machine_skills_sync() {
     # Machine 1 creates skills
     mkdir -p "$MACHINE1_DIR/.claude/skills"
     echo "# Skill from Machine 1" > "$MACHINE1_DIR/.claude/skills/skill-m1.md"
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Machine 2 creates additional skills
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
     mkdir -p "$MACHINE2_DIR/.claude/skills/nested"
     echo "# Nested Skill from Machine 2" > "$MACHINE2_DIR/.claude/skills/nested/skill-m2.md"
-    run_jean_claude "$MACHINE2_DIR" push
+    run_jean_claude "$MACHINE2_DIR" sync push
 
     # Machine 3 creates additional skills
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
     echo "# Skill from Machine 3" > "$MACHINE3_DIR/.claude/skills/skill-m3.md"
-    run_jean_claude "$MACHINE3_DIR" push
+    run_jean_claude "$MACHINE3_DIR" sync push
 
     # Final pull on all machines
-    run_jean_claude "$MACHINE1_DIR" pull
-    run_jean_claude "$MACHINE2_DIR" pull
-    run_jean_claude "$MACHINE3_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
+    run_jean_claude "$MACHINE2_DIR" sync pull
+    run_jean_claude "$MACHINE3_DIR" sync pull
 
     # Verify all machines have all skills
     local all_skills_present=true
@@ -681,10 +682,10 @@ test_three_machine_late_joiner() {
     mkdir -p "$MACHINE4_DIR/.claude"
 
     # Machine4 initializes (joining late)
-    echo "$REMOTE_REPO" | run_jean_claude "$MACHINE4_DIR" init
+    echo "$REMOTE_REPO" | run_jean_claude "$MACHINE4_DIR" init --sync
 
     # Pull to get all existing content
-    run_jean_claude "$MACHINE4_DIR" pull
+    run_jean_claude "$MACHINE4_DIR" sync pull
 
     # Verify machine4 has received all the content created by other machines
     # Check for files from earlier 3-machine tests (skills files from convergence test)
@@ -709,9 +710,9 @@ test_three_machine_status_consistency() {
     print_test "status command consistency across 3 machines"
 
     # Get status from all machines
-    status1=$(run_jean_claude "$MACHINE1_DIR" status 2>&1 || true)
-    status2=$(run_jean_claude "$MACHINE2_DIR" status 2>&1 || true)
-    status3=$(run_jean_claude "$MACHINE3_DIR" status 2>&1 || true)
+    status1=$(run_jean_claude "$MACHINE1_DIR" sync status 2>&1 || true)
+    status2=$(run_jean_claude "$MACHINE2_DIR" sync status 2>&1 || true)
+    status3=$(run_jean_claude "$MACHINE3_DIR" sync status 2>&1 || true)
 
     # All should report some form of status without errors
     local all_status_ok=true
@@ -735,7 +736,7 @@ test_empty_hooks_directory() {
     # Remove all hooks
     rm -rf "$MACHINE1_DIR/.claude/hooks"/*
 
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     # Should handle empty directory gracefully
     print_success "Empty hooks directory handled"
@@ -747,8 +748,8 @@ test_special_characters_in_files() {
     # Create file with special characters
     echo "# Special chars: @#$%^&*()[]{}|\\\"';:<>?/~\`" > "$MACHINE1_DIR/.claude/CLAUDE.md"
 
-    run_jean_claude "$MACHINE1_DIR" push
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync push
+    run_jean_claude "$MACHINE2_DIR" sync pull
 
     if grep -q "Special chars:" "$MACHINE2_DIR/.claude/CLAUDE.md"; then
         print_success "Special characters handled correctly"
@@ -770,8 +771,8 @@ test_large_settings_file() {
         echo '}'
     } > "$MACHINE1_DIR/.claude/settings.json"
 
-    run_jean_claude "$MACHINE1_DIR" push
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync push
+    run_jean_claude "$MACHINE2_DIR" sync pull
 
     assert_file_exists "$MACHINE2_DIR/.claude/settings.json"
 
@@ -791,8 +792,8 @@ test_multiple_hooks() {
         chmod +x "$MACHINE1_DIR/.claude/hooks/hook-$i.sh"
     done
 
-    run_jean_claude "$MACHINE1_DIR" push
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync push
+    run_jean_claude "$MACHINE2_DIR" sync pull
 
     # Verify all hooks are present
     for i in {1..10}; do
@@ -808,8 +809,8 @@ test_nested_hooks_directory() {
     echo "#!/bin/bash\necho 'nested hook'" > "$MACHINE1_DIR/.claude/hooks/utils/helper.sh"
     chmod +x "$MACHINE1_DIR/.claude/hooks/utils/helper.sh"
 
-    run_jean_claude "$MACHINE1_DIR" push
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync push
+    run_jean_claude "$MACHINE2_DIR" sync pull
 
     if [ -f "$MACHINE2_DIR/.claude/hooks/utils/helper.sh" ]; then
         print_success "Nested hook directories supported"
@@ -830,8 +831,8 @@ test_skills_sync() {
     mkdir -p "$MACHINE1_DIR/.claude/skills/advanced"
     echo "# Advanced Skill" > "$MACHINE1_DIR/.claude/skills/advanced/complex-skill.md"
 
-    run_jean_claude "$MACHINE1_DIR" push
-    run_jean_claude "$MACHINE2_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync push
+    run_jean_claude "$MACHINE2_DIR" sync pull
 
     # Verify skills are synced
     assert_file_exists "$MACHINE2_DIR/.claude/skills/custom-skill.md"
@@ -853,7 +854,7 @@ test_missing_claude_md() {
     rm -f "$MACHINE1_DIR/.claude/CLAUDE.md"
 
     # Should still work
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     print_success "Missing CLAUDE.md handled gracefully"
 }
@@ -865,7 +866,7 @@ test_missing_settings_json() {
     rm -f "$MACHINE1_DIR/.claude/settings.json"
 
     # Should still work
-    run_jean_claude "$MACHINE1_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
 
     print_success "Missing settings.json handled gracefully"
 }
@@ -880,7 +881,7 @@ test_git_status_ahead() {
     git commit -m "Test commit" > /dev/null 2>&1 || true
     cd - > /dev/null
 
-    output=$(run_jean_claude "$MACHINE1_DIR" status 2>&1 || true)
+    output=$(run_jean_claude "$MACHINE1_DIR" sync status 2>&1 || true)
 
     # Should show some status information
     print_success "Status command works when ahead of remote"
@@ -896,12 +897,12 @@ test_concurrent_modifications() {
     echo '{"from": "machine2"}' > "$MACHINE2_DIR/.claude/settings.json"
 
     # Both push (machine 1 first)
-    run_jean_claude "$MACHINE1_DIR" push
-    run_jean_claude "$MACHINE2_DIR" pull
-    run_jean_claude "$MACHINE2_DIR" push
+    run_jean_claude "$MACHINE1_DIR" sync push
+    run_jean_claude "$MACHINE2_DIR" sync pull
+    run_jean_claude "$MACHINE2_DIR" sync push
 
     # Machine 1 pulls
-    run_jean_claude "$MACHINE1_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
 
     # Both machines should have both changes
     if grep -q "From Machine 1" "$MACHINE1_DIR/.claude/CLAUDE.md" && \
@@ -920,8 +921,8 @@ test_metadata_persistence() {
     initial_id=$(grep -o '"machineId":"[^"]*"' "$MACHINE1_DIR/.claude/.jean-claude/meta.json" | cut -d'"' -f4)
 
     # Run some commands
-    run_jean_claude "$MACHINE1_DIR" push
-    run_jean_claude "$MACHINE1_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync push
+    run_jean_claude "$MACHINE1_DIR" sync pull
 
     # Check metadata is still the same
     current_id=$(grep -o '"machineId":"[^"]*"' "$MACHINE1_DIR/.claude/.jean-claude/meta.json" | cut -d'"' -f4)
@@ -943,7 +944,7 @@ test_last_sync_timestamp() {
     sleep 1
 
     # Run pull to update timestamp
-    run_jean_claude "$MACHINE1_DIR" pull
+    run_jean_claude "$MACHINE1_DIR" sync pull
 
     # Check updated timestamp
     updated_sync=$(grep -o '"lastSync":"[^"]*"' "$MACHINE1_DIR/.claude/.jean-claude/meta.json" | cut -d'"' -f4)
@@ -1211,18 +1212,18 @@ run_all_tests() {
     test_init_with_existing_repo
     test_init_invalid_remote
 
-    print_header "Testing push command"
+    print_header "Testing sync push command"
     test_push_initial_files
     test_push_no_changes
     test_push_modified_files
     test_push_new_hook
 
-    print_header "Testing pull command"
+    print_header "Testing sync pull command"
     test_pull_basic
     test_pull_overwrites_local
     test_pull_not_initialized
 
-    print_header "Testing status command"
+    print_header "Testing sync status command"
     test_status_clean
     test_status_with_changes
     test_status_not_initialized


### PR DESCRIPTION
## Summary

- Decouples `jean-claude init` from Git so it can be used solely for profile management
- Introduces `jean-claude sync` command group (`setup`, `push`, `pull`, `status`) mirroring the `profile` pattern
- Deprecates top-level `push`/`pull`/`status` with helpful redirect messages
- Adds `--sync`/`--no-sync` flags to `init` for non-interactive use
- Fixes `git push` to use `-u` for proper upstream tracking on first push

Closes #13

## Test plan

- [x] `npm run build` compiles successfully
- [x] `npm run test:unit` — 21 tests pass
- [x] `npm run test:integration` — 49 tests pass (0 failures)
- [ ] Manual: `jean-claude init` without sync, then `jean-claude sync setup` later
- [ ] Manual: `jean-claude push` shows deprecation redirect message