### PR TITLE
Clarify init --sync/--no-sync option descriptions

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,8 +13,8 @@ import { printLogo } from '../utils/logo.js';
 
 export const initCommand = new Command('init')
   .description('Initialize Jean-Claude on this machine')
-  .option('--sync', 'Set up Git-based syncing (skip prompt)')
-  .option('--no-sync', 'Skip syncing setup (skip prompt)')
+  .option('--sync', 'Set up Git-based syncing without prompting')
+  .option('--no-sync', 'Skip Git sync setup without prompting')
   .action(async (options: { sync?: boolean }) => {
     const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
 


### PR DESCRIPTION
## Summary
- Replaces parenthetical "(skip prompt)" phrasing with clearer "without prompting" wording in `init` command option descriptions
- Fixes #21

## Test plan
- [x] Unit tests pass (`npm run test:unit`)
- [ ] Run `npx jean-claude init --help` and verify updated descriptions render correctly