### PR TITLE
Add statusline.sh to profile sync mappings

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -36,6 +36,11 @@ export const FILE_MAPPINGS: FileMapping[] = [
     target: 'keybindings.json',
     type: 'file',
   },
+  {
+    source: 'statusline.sh',
+    target: 'statusline.sh',
+    type: 'file',
+  },
 ];
 
 function fileHash(filePath: string): string | null {


### PR DESCRIPTION
## Summary
- Adds `statusline.sh` as a file mapping in `FILE_MAPPINGS` so it is automatically synced by push/pull/status commands

Closes #16

## Test plan
- [x] Unit tests pass (`npm run test:unit` — 21/21 passing)
- [ ] Manual verification: confirm `statusline.sh` is synced during push/pull operations