### PR TITLE
Allow reconfiguring an existing sync remote

### DIFF
--- a/src/lib/sync-setup.ts
+++ b/src/lib/sync-setup.ts
@@ -16,9 +16,23 @@ export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
   if (isRepo) {
     // Already a git repo — check if remote is configured
     const git = createGit(jeanClaudeDir);
-    const remotes = await git.getRemotes();
+    const remotes = await git.getRemotes(true);
     if (remotes.length > 0) {
+      const origin = remotes.find(r => r.name === 'origin');
+      const currentUrl = origin?.refs?.fetch || 'unknown';
+
       logger.success('Syncing is already configured.');
+      logger.dim(`Current remote: ${currentUrl}`);
+      console.log('');
+
+      const newUrl = (await input('New repository URL (leave empty to keep current):', '')).trim();
+
+      if (newUrl && newUrl !== currentUrl) {
+        await git.remote(['set-url', 'origin', newUrl]);
+        logger.success('Remote URL updated.');
+      } else {
+        logger.dim('Remote URL unchanged.');
+      }
       return;
     }
   }


### PR DESCRIPTION
## Summary
- When `sync setup` detects an existing remote, it now displays the current remote URL and prompts the user to enter a new one
- If the user provides a new URL, the origin remote is updated via `git remote set-url`
- If the user leaves the prompt empty or enters the same URL, the remote is left unchanged

Fixes #19

## Test plan
- [x] Unit tests pass (`npm run test:unit`)
- [ ] Run `jean-claude sync setup` with an already-configured remote and verify it shows the current URL
- [ ] Enter a new URL and verify the remote is updated
- [ ] Leave the prompt empty and verify the remote is unchanged