### PR TITLE
Fix sync push to pull --rebase before pushing

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -120,11 +120,6 @@ export async function pull(dir: string): Promise<{ success: boolean; message: st
   }
 }
 
-export async function pullRebase(dir: string): Promise<void> {
-  const git = createGit(dir);
-  await git.pull(['--rebase']);
-}
-
 export async function commitAndPush(
   dir: string,
   message: string,
@@ -167,7 +162,8 @@ export async function commitAndPush(
       }
 
       try {
-        await git.push();
+        // Use -u to set upstream on first push
+        await git.push(['-u', 'origin', 'HEAD']);
         return { committed: true, pushed: true };
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -120,6 +120,11 @@ export async function pull(dir: string): Promise<{ success: boolean; message: st
   }
 }
 
+export async function pullRebase(dir: string): Promise<void> {
+  const git = createGit(dir);
+  await git.pull(['--rebase']);
+}
+
 export async function commitAndPush(
   dir: string,
   message: string,
@@ -144,6 +149,24 @@ export async function commitAndPush(
     const remotes = await git.getRemotes();
     if (remotes.length > 0) {
       try {
+        await git.pull(['--rebase']);
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        if (errMsg.includes('CONFLICT') || errMsg.includes('conflict')) {
+          throw new JeanClaudeError(
+            `Rebase failed due to conflicts: ${errMsg}`,
+            ErrorCode.MERGE_CONFLICT,
+            'Try running "jean-claude sync pull" to resolve conflicts.'
+          );
+        }
+        throw new JeanClaudeError(
+          `Pull --rebase failed: ${errMsg}`,
+          ErrorCode.NETWORK_ERROR,
+          'Check your network connection and try again.'
+        );
+      }
+
+      try {
         await git.push();
         return { committed: true, pushed: true };
       } catch (err) {
@@ -151,7 +174,7 @@ export async function commitAndPush(
         throw new JeanClaudeError(
           `Push failed: ${errMsg}`,
           ErrorCode.NETWORK_ERROR,
-          'Try running "git push" manually to see the full error.'
+          'Check your network connection and try again.'
         );
       }
     }


### PR DESCRIPTION
## Summary
- Adds git pull --rebase before push in commitAndPush() to handle divergent history
- Distinguishes rebase conflicts (MERGE_CONFLICT) from network errors
- Updates error messages with actionable suggestions
- Adds pullRebase() export for standalone use

Fixes #22