### PR TITLE
Validate repo contains Claude config before syncing

### DIFF
--- a/src/lib/sync-setup.ts
+++ b/src/lib/sync-setup.ts
@@ -2,9 +2,26 @@ import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
 import { logger } from '../utils/logger.js';
-import { input } from '../utils/prompts.js';
+import { confirm, input } from '../utils/prompts.js';
 import { isGitRepo, createGit, initRepo, addRemote, testRemoteConnection, cloneRepo } from './git.js';
+import { readMetaJson } from './sync.js';
 import { JeanClaudeError, ErrorCode } from '../types/index.js';
+
+async function warnIfNotJeanClaudeRepo(dir: string): Promise<void> {
+  const meta = await readMetaJson(dir);
+  if (meta?.managedBy === 'jean-claude') return;
+
+  logger.warn('This repository does not appear to be a Jean-Claude config repo.');
+  logger.dim('It may overwrite your Claude Code configuration with unrelated files.');
+  const proceed = await confirm('Continue anyway?');
+  if (!proceed) {
+    throw new JeanClaudeError(
+      'Setup cancelled — repository validation failed',
+      ErrorCode.INVALID_CONFIG,
+      'Use a repository created by "jean-claude init" with syncing enabled.'
+    );
+  }
+}
 
 /**
  * Interactive Git remote setup flow.
@@ -59,8 +76,10 @@ export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
       // Empty directory — clone directly
       try {
         await cloneRepo(repoUrl, jeanClaudeDir);
+        await warnIfNotJeanClaudeRepo(jeanClaudeDir);
         logger.success('Cloned existing config from repository');
-      } catch {
+      } catch (error) {
+        if (error instanceof JeanClaudeError) throw error;
         await initRepo(jeanClaudeDir);
         await addRemote(jeanClaudeDir, repoUrl);
         logger.success('Initialized new repository');
@@ -70,13 +89,15 @@ export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
       const tmpDir = path.join(os.tmpdir(), `jean-claude-clone-${Date.now()}`);
       try {
         await cloneRepo(repoUrl, tmpDir);
+        await warnIfNotJeanClaudeRepo(tmpDir);
         // Move .git from clone into our directory
         await fs.move(path.join(tmpDir, '.git'), path.join(jeanClaudeDir, '.git'));
         // Reset to match working tree (our existing files take priority)
         const git = createGit(jeanClaudeDir);
         await git.reset(['HEAD']);
         logger.success('Cloned existing config from repository');
-      } catch {
+      } catch (error) {
+        if (error instanceof JeanClaudeError) throw error;
         // Remote is empty — just init locally
         await initRepo(jeanClaudeDir);
         await addRemote(jeanClaudeDir, repoUrl);

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -253,6 +253,7 @@ export function createMetaJson(claudeConfigPath: string): MetaJson {
 
   return {
     version: '1.0.0',
+    managedBy: 'jean-claude',
     lastSync: null,
     machineId: `${hostname}-${machineId}`,
     platform,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export interface FileMapping {
 
 export interface MetaJson {
   version: string;
+  managedBy?: string;
   lastSync: string | null;
   machineId: string;
   platform: string;


### PR DESCRIPTION
## Summary
- Adds `managedBy: 'jean-claude'` field to `MetaJson` interface and `createMetaJson()` output
- After cloning a repo during `sync setup`, validates that `meta.json` contains `managedBy: 'jean-claude'`
- If validation fails, warns the user and asks for confirmation before proceeding — preventing accidental overwrites from unrelated repositories
- Reuses existing `readMetaJson()` utility and extracts a `warnIfNotJeanClaudeRepo()` helper to avoid duplication

Closes #1

## Test plan
- [x] Unit tests pass (`npm run test:unit` — 21/21 passing)
- [ ] Manual: run `jean-claude sync setup` with a valid jean-claude repo — should proceed without warning
- [ ] Manual: run `jean-claude sync setup` with an unrelated repo — should show warning and prompt
- [ ] Manual: decline the prompt — should abort with error
- [ ] Manual: accept the prompt — should continue setup