### PR TITLE
Add --url flag for non-interactive sync setup

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,7 +15,8 @@ export const initCommand = new Command('init')
   .description('Initialize Jean-Claude on this machine')
   .option('--sync', 'Set up Git-based syncing without prompting')
   .option('--no-sync', 'Skip Git sync setup without prompting')
-  .action(async (options: { sync?: boolean }) => {
+  .option('--url <repo-url>', 'Repository URL for sync setup (implies --sync)')
+  .action(async (options: { sync?: boolean; url?: string }) => {
     const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
 
     printLogo();
@@ -40,9 +41,10 @@ export const initCommand = new Command('init')
       logger.info('Found existing Git repository — reusing it.');
     }
 
-    // Ask about syncing (unless --sync or --no-sync was provided)
     let wantSync: boolean;
-    if (options.sync !== undefined) {
+    if (options.url) {
+      wantSync = true;
+    } else if (options.sync !== undefined) {
       wantSync = options.sync;
     } else {
       console.log('');
@@ -50,7 +52,7 @@ export const initCommand = new Command('init')
     }
 
     if (wantSync) {
-      await setupGitSync(jeanClaudeDir);
+      await setupGitSync(jeanClaudeDir, options.url);
     }
 
     // Done

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -18,7 +18,8 @@ function generateCommitMessage(): string {
 
 const syncSetupCommand = new Command('setup')
   .description('Set up Git-based syncing for your configuration')
-  .action(async () => {
+  .option('--url <repo-url>', 'Repository URL (skip interactive prompt)')
+  .action(async (options: { url?: string }) => {
     const { jeanClaudeDir } = getConfigPaths();
 
     if (!fs.existsSync(jeanClaudeDir)) {
@@ -29,7 +30,7 @@ const syncSetupCommand = new Command('setup')
       );
     }
 
-    await setupGitSync(jeanClaudeDir);
+    await setupGitSync(jeanClaudeDir, options.url);
 
     console.log('');
     logger.dim('Next steps:');

--- a/src/lib/sync-setup.ts
+++ b/src/lib/sync-setup.ts
@@ -27,7 +27,7 @@ async function warnIfNotJeanClaudeRepo(dir: string): Promise<void> {
  * Interactive Git remote setup flow.
  * Used by both `jean-claude init` (when user opts in) and `jean-claude sync setup`.
  */
-export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
+export async function setupGitSync(jeanClaudeDir: string, urlArg?: string): Promise<void> {
   const isRepo = await isGitRepo(jeanClaudeDir);
 
   if (isRepo) {
@@ -40,9 +40,14 @@ export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
 
       logger.success('Syncing is already configured.');
       logger.dim(`Current remote: ${currentUrl}`);
-      console.log('');
 
-      const newUrl = (await input('New repository URL (leave empty to keep current):', '')).trim();
+      let newUrl: string;
+      if (urlArg) {
+        newUrl = urlArg.trim();
+      } else {
+        console.log('');
+        newUrl = (await input('New repository URL (leave empty to keep current):', '')).trim();
+      }
 
       if (newUrl && newUrl !== currentUrl) {
         await git.remote(['set-url', 'origin', newUrl]);
@@ -54,14 +59,24 @@ export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
     }
   }
 
-  // Explain what's needed
-  console.log('');
-  logger.dim('Paste the URL of your existing config repo, or create a new');
-  logger.dim('empty repo (e.g. "my-claude-config") on GitHub/GitLab.');
-  console.log('');
+  let repoUrl = urlArg;
+  if (!repoUrl) {
+    // Explain what's needed
+    console.log('');
+    logger.dim('Paste the URL of your existing config repo, or create a new');
+    logger.dim('empty repo (e.g. "my-claude-config") on GitHub/GitLab.');
+    console.log('');
 
-  // Get repository URL
-  const repoUrl = await input('Repository URL:');
+    repoUrl = await input('Repository URL:');
+  }
+
+  if (!repoUrl.trim()) {
+    throw new JeanClaudeError(
+      'No repository URL provided',
+      ErrorCode.INVALID_CONFIG,
+      'Provide a Git repository URL (e.g. git@github.com:user/repo.git).'
+    );
+  }
 
   // Test connection to remote
   logger.step(1, 2, 'Testing connection to repository...');


### PR DESCRIPTION
## Summary
- Adds `--url <repo-url>` option to `jean-claude sync setup` and `jean-claude init` to skip the interactive repository URL prompt
- When used with `init`, `--url` implies `--sync`
- The flag also works when reconfiguring an existing remote (skips the reconfigure prompt)
- Adds validation that throws a clear error if an empty URL is provided

Closes #31

## Test plan
- [ ] Run `jean-claude sync setup --url git@github.com:user/repo.git` and verify it skips the prompt
- [ ] Run `jean-claude init --url git@github.com:user/repo.git` and verify it implies `--sync` and skips the prompt
- [ ] Run `jean-claude sync setup` without `--url` and verify interactive prompt still works
- [ ] Run `jean-claude sync setup --url ""` and verify it throws a clear error
- [ ] Run `jean-claude sync setup --url <new-url>` on an already-configured repo and verify it updates the remote