### PR TITLE
Add --url flag for non-interactive sync reconfigure

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,7 +15,8 @@ export const initCommand = new Command('init')
   .description('Initialize Jean-Claude on this machine')
   .option('--sync', 'Set up Git-based syncing without prompting')
   .option('--no-sync', 'Skip Git sync setup without prompting')
-  .action(async (options: { sync?: boolean }) => {
+  .option('--url <repo-url>', 'Repository URL for sync setup (implies --sync)')
+  .action(async (options: { sync?: boolean; url?: string }) => {
     const { jeanClaudeDir, claudeConfigDir } = getConfigPaths();
 
     printLogo();
@@ -41,8 +42,11 @@ export const initCommand = new Command('init')
     }
 
     // Ask about syncing (unless --sync or --no-sync was provided)
+    // --url implies --sync
     let wantSync: boolean;
-    if (options.sync !== undefined) {
+    if (options.url) {
+      wantSync = true;
+    } else if (options.sync !== undefined) {
       wantSync = options.sync;
     } else {
       console.log('');
@@ -50,7 +54,7 @@ export const initCommand = new Command('init')
     }
 
     if (wantSync) {
-      await setupGitSync(jeanClaudeDir);
+      await setupGitSync(jeanClaudeDir, options.url);
     }
 
     // Done

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -18,7 +18,8 @@ function generateCommitMessage(): string {
 
 const syncSetupCommand = new Command('setup')
   .description('Set up Git-based syncing for your configuration')
-  .action(async () => {
+  .option('--url <repo-url>', 'Repository URL (skips interactive prompt)')
+  .action(async (options: { url?: string }) => {
     const { jeanClaudeDir } = getConfigPaths();
 
     if (!fs.existsSync(jeanClaudeDir)) {
@@ -29,7 +30,7 @@ const syncSetupCommand = new Command('setup')
       );
     }
 
-    await setupGitSync(jeanClaudeDir);
+    await setupGitSync(jeanClaudeDir, options.url);
 
     console.log('');
     logger.dim('Next steps:');

--- a/src/lib/sync-setup.ts
+++ b/src/lib/sync-setup.ts
@@ -24,10 +24,11 @@ async function warnIfNotJeanClaudeRepo(dir: string): Promise<void> {
 }
 
 /**
- * Interactive Git remote setup flow.
+ * Git remote setup flow.
  * Used by both `jean-claude init` (when user opts in) and `jean-claude sync setup`.
+ * When urlArg is provided, skips interactive prompts for the repository URL.
  */
-export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
+export async function setupGitSync(jeanClaudeDir: string, urlArg?: string): Promise<void> {
   const isRepo = await isGitRepo(jeanClaudeDir);
 
   if (isRepo) {
@@ -42,7 +43,8 @@ export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
       logger.dim(`Current remote: ${currentUrl}`);
       console.log('');
 
-      const newUrl = (await input('New repository URL (leave empty to keep current):', '')).trim();
+      const newUrl = urlArg?.trim()
+        || (await input('New repository URL (leave empty to keep current):', '')).trim();
 
       if (newUrl && newUrl !== currentUrl) {
         await git.remote(['set-url', 'origin', newUrl]);
@@ -54,14 +56,17 @@ export async function setupGitSync(jeanClaudeDir: string): Promise<void> {
     }
   }
 
-  // Explain what's needed
-  console.log('');
-  logger.dim('Paste the URL of your existing config repo, or create a new');
-  logger.dim('empty repo (e.g. "my-claude-config") on GitHub/GitLab.');
-  console.log('');
-
-  // Get repository URL
-  const repoUrl = await input('Repository URL:');
+  // Get repository URL — use flag if provided, otherwise prompt
+  let repoUrl: string;
+  if (urlArg) {
+    repoUrl = urlArg;
+  } else {
+    console.log('');
+    logger.dim('Paste the URL of your existing config repo, or create a new');
+    logger.dim('empty repo (e.g. "my-claude-config") on GitHub/GitLab.');
+    console.log('');
+    repoUrl = await input('Repository URL:');
+  }
 
   // Test connection to remote
   logger.step(1, 2, 'Testing connection to repository...');


### PR DESCRIPTION
## Summary
- Adds optional `urlArg` parameter to `setupGitSync()` so both the initial setup and reconfigure paths can skip interactive prompts when a URL is provided via `--url`
- Adds `--url <repo-url>` option to `jean-claude sync setup` command
- Adds `--url <repo-url>` option to `jean-claude init` command (implies `--sync`)

Closes #32

## Test plan
- [ ] Run `jean-claude sync setup --url <repo>` on a fresh init — should skip URL prompt
- [ ] Run `jean-claude sync setup --url <new-repo>` when a remote already exists — should update without prompting
- [ ] Run `jean-claude sync setup` without `--url` — interactive behavior unchanged
- [ ] Run `jean-claude init --url <repo>` — should imply `--sync` and skip URL prompt