### PR TITLE
Fix first sync push failing on new repo with no upstream

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -143,8 +143,30 @@ export async function commitAndPush(
   if (push) {
     const remotes = await git.getRemotes();
     if (remotes.length > 0) {
+      // Only pull --rebase if we have an upstream tracking branch
+      if (status.tracking) {
+        try {
+          await git.pull(['--rebase']);
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          if (errMsg.includes('CONFLICT') || errMsg.includes('conflict')) {
+            throw new JeanClaudeError(
+              `Rebase failed due to conflicts: ${errMsg}`,
+              ErrorCode.MERGE_CONFLICT,
+              'Try running "jean-claude sync pull" to resolve conflicts.'
+            );
+          }
+          throw new JeanClaudeError(
+            `Pull --rebase failed: ${errMsg}`,
+            ErrorCode.NETWORK_ERROR,
+            'Check your network connection and try again.'
+          );
+        }
+      }
+
       try {
-        await git.push();
+        // Use -u to set upstream on first push
+        await git.push(['-u', 'origin', 'HEAD']);
         return { committed: true, pushed: true };
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Check for an upstream tracking branch before attempting `pull --rebase` in `commitAndPush()`. On a fresh repo with no upstream, the pull would fail with a cryptic error.
- Restores `-u` flag on `git push` to set upstream tracking on first push.
- Reuses existing `git.status()` result instead of making a redundant call.

Fixes #36

## Test plan
- [x] Unit tests pass (`npm run test:unit`)
- [ ] Manual: init a new jean-claude repo with a remote but no upstream, run `jean-claude sync push` — should succeed without pull error
- [ ] Manual: on a repo with an existing upstream, run `jean-claude sync push` — should pull --rebase before pushing