### PR TITLE
Warn when --url and --no-sync are used together

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -43,6 +43,9 @@ export const initCommand = new Command('init')
 
     let wantSync: boolean;
     if (options.url) {
+      if (options.sync === false) {
+        logger.warn('--url implies --sync; ignoring --no-sync.');
+      }
       wantSync = true;
     } else if (options.sync !== undefined) {
       wantSync = options.sync;


### PR DESCRIPTION
## Summary
- When `jean-claude init --url <url> --no-sync` is used, shows a warning that `--url` implies `--sync` and `--no-sync` is ignored
- One-line addition to init.ts

Fixes #38