### PR TITLE
Add GitHub Actions CI/CD workflow for running tests (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - 'release/*'
+  pull_request:
+    branches:
+      - master
+      - 'release/*'
+
+jobs:
+  build:
+    name: Build & Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18, 20]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Integration tests
+        run: npm run test:integration


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with a CI pipeline triggered on pushes and PRs to `master` and `release/*` branches
- Runs build, unit tests, and integration tests across a Node.js 18/20 matrix on Ubuntu
- Uses npm cache via `actions/setup-node@v4` for faster installs

Closes #50

## Test plan
- [ ] Verify workflow triggers on PR to `release/2.0.0`
- [ ] Confirm both Node 18 and Node 20 matrix jobs run successfully
- [ ] Confirm `npm ci`, `npm run build`, `npm run test:unit`, and `npm run test:integration` all pass in CI