### PR TITLE
Improve CLI output styling across all commands

### DIFF
--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -50,14 +50,16 @@ const profileCreateCommand = new Command('create')
 
     logger.heading(`Creating profile: ${name}`);
     console.log();
-    logger.info(`Config directory: ${chalk.cyan(formatPath(configDir))}`);
-    logger.info(`Shell alias:      ${chalk.cyan(`claude-${name}`)}`);
+    logger.table([
+      ['Config directory', chalk.cyan(formatPath(configDir))],
+      ['Shell alias', chalk.cyan(`claude-${name}`)],
+    ]);
     console.log();
 
-    logger.info('The following items will be symlinked from your main config:');
+    logger.dim('The following items will be symlinked from your main config:');
     logger.list(SHARED_ITEMS.map((i) => i.name));
     console.log();
-    logger.info(
+    logger.dim(
       'Profile-specific files (like CLAUDE.md) will be independent.'
     );
     console.log();
@@ -93,15 +95,11 @@ const profileCreateCommand = new Command('create')
     console.log();
     logger.heading('Next steps');
     console.log();
-    logger.info(
-      `Reload your shell or run: ${chalk.cyan(`source ~/${shellFile}`)}`
-    );
-    logger.info(
-      `Then use ${chalk.cyan(`claude-${name}`)} to launch Claude Code with this profile.`
-    );
-    logger.info(
-      `Edit ${chalk.cyan(formatPath(configDir) + '/CLAUDE.md')} to add profile-specific instructions.`
-    );
+    logger.list([
+      `Reload your shell or run: ${chalk.cyan(`source ~/${shellFile}`)}`,
+      `Then use ${chalk.cyan(`claude-${name}`)} to launch Claude Code with this profile.`,
+      `Edit ${chalk.cyan(formatPath(configDir) + '/CLAUDE.md')} to add profile-specific instructions.`,
+    ]);
   });
 
 const profileListCommand = new Command('list')
@@ -111,7 +109,7 @@ const profileListCommand = new Command('list')
     const names = Object.keys(config.profiles);
 
     if (names.length === 0) {
-      logger.info('No profiles configured.');
+      logger.dim('No profiles configured.');
       logger.dim('Create one with: jean-claude profile create <name>');
       return;
     }
@@ -169,7 +167,7 @@ const profileDeleteCommand = new Command('delete')
     const names = Object.keys(config.profiles);
 
     if (names.length === 0) {
-      logger.info('No profiles to delete.');
+      logger.dim('No profiles to delete.');
       return;
     }
 
@@ -196,7 +194,7 @@ const profileDeleteCommand = new Command('delete')
       `This will remove ${chalk.cyan(formatPath(profile.configDir))} and its contents.`
     );
     logger.warn('Profile-specific files (like CLAUDE.md) will be lost.');
-    logger.info('Shared files in your main ~/.claude/ are not affected (they are the originals).');
+    logger.dim('Shared files in your main ~/.claude/ are not affected (they are the originals).');
     console.log();
 
     if (!options.yes) {
@@ -234,7 +232,7 @@ const profileRefreshCommand = new Command('refresh')
     const names = Object.keys(config.profiles);
 
     if (names.length === 0) {
-      logger.info('No profiles configured.');
+      logger.dim('No profiles configured.');
       return;
     }
 
@@ -245,7 +243,7 @@ const profileRefreshCommand = new Command('refresh')
         names.map((n) => ({ name: n, value: n }))
       ));
 
-    logger.info(`Refreshing symlinks for profile "${name}"...`);
+    logger.dim(`Refreshing symlinks for profile "${name}"...`);
     const created = await refreshSymlinks(name);
     logger.success(`Symlinks refreshed: ${created.join(', ')}`);
   });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,7 @@
 import chalk from 'chalk';
 
+const orange = chalk.hex('#FF6B4A');
+
 export const logger = {
   info: (msg: string) => console.log(chalk.blue('info') + ' ' + msg),
   success: (msg: string) => console.log(chalk.green('✓') + ' ' + msg),
@@ -10,9 +12,25 @@ export const logger = {
     console.log(chalk.dim(`[${num}/${total}]`) + ' ' + msg);
   },
 
+  banner: (title: string, subtitle?: string) => {
+    const lines = [title];
+    if (subtitle) lines.push(subtitle);
+    const maxLen = Math.max(...lines.map((l) => l.length));
+    const width = maxLen + 4;
+    const border = chalk.dim;
+
+    console.log('');
+    console.log(border('╭' + '─'.repeat(width) + '╮'));
+    for (const line of lines) {
+      const padded = line.padEnd(maxLen);
+      console.log(border('│') + '  ' + orange(padded) + '  ' + border('│'));
+    }
+    console.log(border('╰' + '─'.repeat(width) + '╯'));
+  },
+
   heading: (msg: string) => {
-    console.log('\n' + chalk.bold(msg));
-    console.log(chalk.dim('─'.repeat(msg.length)));
+    console.log('');
+    console.log(orange('■') + ' ' + chalk.bold(msg));
   },
 
   dim: (msg: string) => console.log(chalk.dim(msg)),

--- a/src/utils/logo.ts
+++ b/src/utils/logo.ts
@@ -1,9 +1,5 @@
-import chalk from 'chalk';
+import { logger } from './logger.js';
 
 export function printLogo(): void {
-  const o = chalk.hex('#FF6B4A');
-  const g = chalk.gray;
-
-  console.log('\n' + o('JEAN-CLAUDE'));
-  console.log(g('A companion for syncing Claude Code configuration\n'));
+  logger.banner('JEAN-CLAUDE', 'A companion for syncing Claude Code');
 }


### PR DESCRIPTION
## Summary
- Added `banner()` method to the logger for rendering boxed headers with Unicode border characters and the brand orange color
- Updated `heading()` to use an orange block marker instead of a dim underline for cleaner visual hierarchy
- Replaced the standalone logo implementation with a call to `logger.banner()`, centralizing the brand color
- Removed all `logger.info()` calls from command files (profile create/list/delete/refresh) where the "info" prefix added noise, replacing them with `logger.dim()`, `logger.table()`, and `logger.list()` for cleaner output
- Reserved prefixed output for `warning` and `error` only

Closes #59

## Test plan
- [x] Unit tests pass (`npm run test:unit` -- 21 tests, 3 suites)
- [x] Integration tests pass (`npm run test:integration` -- 103 assertions, 0 failures)
- [x] Build succeeds (`npm run build`)