### PR TITLE
feat: portable ~ paths in config for cross-machine sync

### DIFF
--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import { getConfigPaths, getJeanClaudeDir } from './paths.js';
 import { JeanClaudeError, ErrorCode } from '../types/index.js';
 import type { ProfileConfig, Profile } from '../types/index.js';
+import { expandPath, formatPath } from '../utils/logger.js';
 
 const PROFILES_FILE = 'profiles.json';
 
@@ -27,7 +28,12 @@ function getProfilesPath(): string {
 export async function loadProfiles(): Promise<ProfileConfig> {
   const profilesPath = getProfilesPath();
   if (await fs.pathExists(profilesPath)) {
-    return await fs.readJson(profilesPath);
+    const config: ProfileConfig = await fs.readJson(profilesPath);
+    // Expand ~ to absolute paths for runtime use
+    for (const profile of Object.values(config.profiles)) {
+      profile.configDir = expandPath(profile.configDir);
+    }
+    return config;
   }
   return { profiles: {} };
 }
@@ -35,7 +41,16 @@ export async function loadProfiles(): Promise<ProfileConfig> {
 export async function saveProfiles(config: ProfileConfig): Promise<void> {
   const profilesPath = getProfilesPath();
   const tmpPath = `${profilesPath}.${process.pid}.tmp`;
-  await fs.writeJson(tmpPath, config, { spaces: 2 });
+  // Store paths with ~ for portability across machines
+  const portableConfig: ProfileConfig = {
+    profiles: Object.fromEntries(
+      Object.entries(config.profiles).map(([name, profile]) => [
+        name,
+        { ...profile, configDir: formatPath(profile.configDir) },
+      ])
+    ),
+  };
+  await fs.writeJson(tmpPath, portableConfig, { spaces: 2 });
   await fs.rename(tmpPath, profilesPath);
 }
 

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import os from 'os';
 import type { FileMapping, SyncResult, MetaJson } from '../types/index.js';
 import { getConfigPaths } from './paths.js';
+import { expandPath, formatPath } from '../utils/logger.js';
 
 export const FILE_MAPPINGS: FileMapping[] = [
   {
@@ -262,7 +263,7 @@ export function createMetaJson(claudeConfigPath: string): MetaJson {
     lastSync: null,
     machineId: `${hostname}-${machineId}`,
     platform,
-    claudeConfigPath,
+    claudeConfigPath: formatPath(claudeConfigPath),
   };
 }
 
@@ -272,7 +273,9 @@ export async function readMetaJson(jeanClaudeDir: string): Promise<MetaJson | nu
     return null;
   }
   try {
-    return await fs.readJson(metaPath);
+    const meta: MetaJson = await fs.readJson(metaPath);
+    meta.claudeConfigPath = expandPath(meta.claudeConfigPath);
+    return meta;
   } catch {
     return null;
   }
@@ -283,7 +286,8 @@ export async function writeMetaJson(
   meta: MetaJson
 ): Promise<void> {
   const metaPath = path.join(jeanClaudeDir, 'meta.json');
-  await fs.writeJson(metaPath, meta, { spaces: 2 });
+  const portableMeta = { ...meta, claudeConfigPath: formatPath(meta.claudeConfigPath) };
+  await fs.writeJson(metaPath, portableMeta, { spaces: 2 });
 }
 
 export async function updateLastSync(jeanClaudeDir: string): Promise<void> {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,6 @@
 import chalk from 'chalk';
+import os from 'os';
+import path from 'path';
 
 const orange = chalk.hex('#FF6B4A');
 
@@ -51,6 +53,17 @@ export function formatPath(p: string): string {
   const home = process.env.HOME || '';
   if (home && p.startsWith(home)) {
     return '~' + p.slice(home.length);
+  }
+  return p;
+}
+
+/**
+ * Expand a leading ~ to the user's home directory.
+ * Enables portable paths in config files across machines.
+ */
+export function expandPath(p: string): string {
+  if (p.startsWith('~/') || p === '~') {
+    return path.join(os.homedir(), p.slice(1));
   }
   return p;
 }


### PR DESCRIPTION
## Summary

- Adds `expandPath()` utility to expand `~` to `os.homedir()` at runtime
- `profiles.json` and `meta.json` now store paths with `~` instead of absolute home directories (e.g. `~/.claude-work` instead of `/Users/sroy/.claude-work`)
- Paths are expanded on read and formatted on write — no changes to runtime behavior

This makes config files portable across machines with different usernames and benefits users who track their `.claude` directory in a dotfiles repo.

## Files changed

- `src/utils/logger.ts` — new `expandPath()` function
- `src/lib/profiles.ts` — expand on load, format on save
- `src/lib/sync.ts` — expand on read, format on write for meta.json

## Test plan

- [x] `npm run build` passes
- [x] All 186 tests pass (unit + integration)
- [x] Verified idempotency: double-expand and double-format are safe no-ops