### PR TITLE
fix(sync): reconcile divergent branches on `sync pull`

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -92,21 +92,59 @@ export async function getGitStatus(dir: string): Promise<GitStatus> {
   };
 }
 
+/**
+ * Pull from the upstream tracking branch, rebasing local commits on top of it.
+ *
+ * A plain `git pull` refuses to integrate when local and remote history have
+ * diverged (`fatal: Need to specify how to reconcile divergent branches`),
+ * which happens routinely when two machines sync without pulling in between.
+ * Rebasing keeps the history linear. Divergence that conflicts only on
+ * `meta.json` (per-machine metadata that is regenerated on every sync) is
+ * resolved automatically: `--ours` during a rebase is the upstream side, so
+ * the remote copy is kept — which side wins is immaterial since it is
+ * rewritten on the next sync. Any other conflict aborts the rebase and is
+ * surfaced to the caller.
+ */
+async function pullWithRebase(git: SimpleGit): Promise<void> {
+  try {
+    await git.pull(['--rebase']);
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    if (errMsg.includes('CONFLICT') || errMsg.includes('conflict')) {
+      const conflictStatus = await git.status();
+      const conflictFiles = conflictStatus.conflicted;
+      if (conflictFiles.length === 1 && conflictFiles[0] === 'meta.json') {
+        await git.checkout(['--ours', 'meta.json']);
+        await git.add('meta.json');
+        await git.env('GIT_EDITOR', 'true').rebase(['--continue']);
+        return;
+      }
+      await git.rebase(['--abort']);
+    }
+    throw err;
+  }
+}
+
 export async function pull(dir: string): Promise<{ success: boolean; message: string }> {
   const git = createGit(dir);
 
   try {
-    const result = await git.pull();
-    if (result.summary.changes === 0) {
+    const before = await git.revparse(['HEAD']);
+    await pullWithRebase(git);
+    const after = await git.revparse(['HEAD']);
+
+    if (before === after) {
       return { success: true, message: 'Already up to date.' };
     }
+
+    const diff = await git.diffSummary([`${before}..${after}`]);
     return {
       success: true,
-      message: `Updated: ${result.summary.insertions} insertions, ${result.summary.deletions} deletions`,
+      message: `Updated: ${diff.insertions} insertions, ${diff.deletions} deletions`,
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    if (message.includes('CONFLICT')) {
+    if (message.includes('CONFLICT') || message.includes('conflict')) {
       throw new JeanClaudeError(
         'Merge conflict detected',
         ErrorCode.MERGE_CONFLICT,
@@ -146,25 +184,15 @@ export async function commitAndPush(
       // Only pull --rebase if we have an upstream tracking branch
       if (status.tracking) {
         try {
-          await git.pull(['--rebase']);
+          await pullWithRebase(git);
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err);
           if (errMsg.includes('CONFLICT') || errMsg.includes('conflict')) {
-            // Check if meta.json is the only conflicting file — auto-resolve it
-            const conflictStatus = await git.status();
-            const conflictFiles = conflictStatus.conflicted;
-            if (conflictFiles.length === 1 && conflictFiles[0] === 'meta.json') {
-              await git.checkout(['--ours', 'meta.json']);
-              await git.add('meta.json');
-              await git.env('GIT_EDITOR', 'true').rebase(['--continue']);
-            } else {
-              await git.rebase(['--abort']);
-              throw new JeanClaudeError(
-                `Rebase failed due to conflicts: ${errMsg}`,
-                ErrorCode.MERGE_CONFLICT,
-                'Try running "jean-claude sync pull" to resolve conflicts.'
-              );
-            }
+            throw new JeanClaudeError(
+              `Rebase failed due to conflicts: ${errMsg}`,
+              ErrorCode.MERGE_CONFLICT,
+              'Try running "jean-claude sync pull" to resolve conflicts.'
+            );
           } else if (errMsg.includes('no such ref') || errMsg.includes("Couldn't find remote ref")) {
             // Remote branch doesn't exist yet — skip rebase, first push will create it
           } else {

--- a/tests/unit/lib/git.test.ts
+++ b/tests/unit/lib/git.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
 import { simpleGit } from 'simple-git';
-import { commitAndPush } from '../../../src/lib/git.js';
+import { commitAndPush, pull } from '../../../src/lib/git.js';
 
 describe('git.ts', () => {
   let tempDir: string;
@@ -144,6 +144,124 @@ describe('git.ts', () => {
       const messages = log.all.map((c) => c.message);
       expect(messages).toContain('machine1 commit');
       expect(messages).toContain('machine2 commit');
+    });
+  });
+
+  describe('pull', () => {
+    // Reproduces the "Need to specify how to reconcile divergent branches"
+    // failure: local has an unpushed commit while the remote has moved on, so
+    // history has diverged. A plain `git pull` aborts; pull() must rebase.
+    it('should reconcile divergent branches by rebasing', async () => {
+      const machine1Dir = path.join(tempDir, 'machine1');
+      const machine2Dir = path.join(tempDir, 'machine2');
+      const bareDir = path.join(tempDir, 'remote.git');
+
+      // machine1: initial commit, pushed to a shared bare remote
+      await fs.ensureDir(machine1Dir);
+      const git1 = simpleGit(machine1Dir);
+      await git1.init();
+      await git1.addConfig('user.email', 'test@test.com');
+      await git1.addConfig('user.name', 'Test');
+      await fs.writeFile(path.join(machine1Dir, 'init.txt'), 'init');
+      await git1.add('-A');
+      await git1.commit('initial commit');
+      await simpleGit().clone(machine1Dir, bareDir, ['--bare']);
+      try { await git1.removeRemote('origin'); } catch { /* ignore */ }
+      await git1.addRemote('origin', bareDir);
+      await git1.push(['-u', 'origin', 'HEAD']);
+
+      // machine2 clones, commits and pushes — advancing the remote
+      await simpleGit().clone(bareDir, machine2Dir);
+      const git2 = simpleGit(machine2Dir);
+      await git2.addConfig('user.email', 'test@test.com');
+      await git2.addConfig('user.name', 'Test');
+      await fs.writeFile(path.join(machine2Dir, 'machine2.txt'), 'from machine 2');
+      await git2.add('-A');
+      await git2.commit('machine2 commit');
+      await git2.push();
+
+      // machine1 makes its own local commit WITHOUT pulling first — history
+      // has now diverged (1 ahead, 1 behind).
+      await fs.writeFile(path.join(machine1Dir, 'machine1.txt'), 'from machine 1');
+      await git1.add('-A');
+      await git1.commit('machine1 commit');
+
+      // A bare `git pull` here fails; pull() should rebase and succeed.
+      const result = await pull(machine1Dir);
+      expect(result.success).toBe(true);
+
+      const log = await git1.log();
+      const messages = log.all.map((c) => c.message);
+      expect(messages).toContain('machine1 commit');
+      expect(messages).toContain('machine2 commit');
+    });
+
+    it('should auto-resolve a meta.json-only conflict on divergence', async () => {
+      const machine1Dir = path.join(tempDir, 'machine1');
+      const machine2Dir = path.join(tempDir, 'machine2');
+      const bareDir = path.join(tempDir, 'remote.git');
+
+      // Shared history that already contains meta.json
+      await fs.ensureDir(machine1Dir);
+      const git1 = simpleGit(machine1Dir);
+      await git1.init();
+      await git1.addConfig('user.email', 'test@test.com');
+      await git1.addConfig('user.name', 'Test');
+      await fs.writeFile(path.join(machine1Dir, 'meta.json'), '{"lastSync":"base"}');
+      await git1.add('-A');
+      await git1.commit('initial commit');
+      await simpleGit().clone(machine1Dir, bareDir, ['--bare']);
+      try { await git1.removeRemote('origin'); } catch { /* ignore */ }
+      await git1.addRemote('origin', bareDir);
+      await git1.push(['-u', 'origin', 'HEAD']);
+
+      // machine2 changes meta.json and pushes
+      await simpleGit().clone(bareDir, machine2Dir);
+      const git2 = simpleGit(machine2Dir);
+      await git2.addConfig('user.email', 'test@test.com');
+      await git2.addConfig('user.name', 'Test');
+      await fs.writeFile(path.join(machine2Dir, 'meta.json'), '{"lastSync":"machine2"}');
+      await git2.add('-A');
+      await git2.commit('machine2 meta update');
+      await git2.push();
+
+      // machine1 changes meta.json to a different value — divergent + conflicting
+      await fs.writeFile(path.join(machine1Dir, 'meta.json'), '{"lastSync":"machine1"}');
+      await git1.add('-A');
+      await git1.commit('machine1 meta update');
+
+      const result = await pull(machine1Dir);
+      expect(result.success).toBe(true);
+
+      // The conflict is auto-resolved and the rebase completes cleanly — no
+      // lingering conflict markers or in-progress rebase. During a rebase
+      // `--ours` is the upstream side, so the remote copy is kept (immaterial
+      // in practice since meta.json is regenerated on the next sync).
+      const status = await git1.status();
+      expect(status.conflicted).toEqual([]);
+      const meta = await fs.readFile(path.join(machine1Dir, 'meta.json'), 'utf-8');
+      expect(meta).toContain('machine2');
+    });
+
+    it('should report already up to date when there is nothing to pull', async () => {
+      const machine1Dir = path.join(tempDir, 'machine1');
+      const bareDir = path.join(tempDir, 'remote.git');
+
+      await fs.ensureDir(machine1Dir);
+      const git1 = simpleGit(machine1Dir);
+      await git1.init();
+      await git1.addConfig('user.email', 'test@test.com');
+      await git1.addConfig('user.name', 'Test');
+      await fs.writeFile(path.join(machine1Dir, 'init.txt'), 'init');
+      await git1.add('-A');
+      await git1.commit('initial commit');
+      await simpleGit().clone(machine1Dir, bareDir, ['--bare']);
+      try { await git1.removeRemote('origin'); } catch { /* ignore */ }
+      await git1.addRemote('origin', bareDir);
+      await git1.push(['-u', 'origin', 'HEAD']);
+
+      const result = await pull(machine1Dir);
+      expect(result).toEqual({ success: true, message: 'Already up to date.' });
     });
   });
 });


### PR DESCRIPTION
This PR adds tests for the new `pullWithRebase` functionality
- The implementation simplifies the code by removing duplication
- The documentation explains the rebase logic clearly