### PR TITLE
feat: portable ~ paths in config files (continues #66)

### DIFF
--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -54,3 +54,33 @@ export function ensureDir(dirPath: string): void {
     fs.mkdirSync(dirPath, { recursive: true });
   }
 }
+
+/**
+ * Expand a leading ~ to the user's home directory.
+ * Inverse of contractPath; used when reading config files from disk.
+ * Passes through absolute paths, relative paths, and falsy values unchanged.
+ */
+export function expandPath(p: string): string {
+  if (!p) return p;
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~' + path.sep)) {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Replace the user's home directory prefix with ~ so config files stay
+ * portable across machines. Only contracts at a path boundary: a sibling
+ * directory like /Users/mikeshared is left untouched, since ~shared/...
+ * would not survive the round-trip through expandPath.
+ */
+export function contractPath(p: string): string {
+  if (!p) return p;
+  const home = os.homedir();
+  if (p === home) return '~';
+  if (p.startsWith(home + path.sep)) {
+    return '~' + p.slice(home.length);
+  }
+  return p;
+}

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,10 +1,9 @@
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-import { getConfigPaths, getJeanClaudeDir } from './paths.js';
+import { getConfigPaths, getJeanClaudeDir, expandPath, contractPath } from './paths.js';
 import { JeanClaudeError, ErrorCode } from '../types/index.js';
 import type { ProfileConfig, Profile } from '../types/index.js';
-import { expandPath, formatPath } from '../utils/logger.js';
 
 const PROFILES_FILE = 'profiles.json';
 
@@ -46,7 +45,7 @@ export async function saveProfiles(config: ProfileConfig): Promise<void> {
     profiles: Object.fromEntries(
       Object.entries(config.profiles).map(([name, profile]) => [
         name,
-        { ...profile, configDir: formatPath(profile.configDir) },
+        { ...profile, configDir: contractPath(profile.configDir) },
       ])
     ),
   };

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import { getConfigPaths, getJeanClaudeDir } from './paths.js';
 import { JeanClaudeError, ErrorCode } from '../types/index.js';
 import type { ProfileConfig, Profile } from '../types/index.js';
+import { expandPath, formatPath } from '../utils/logger.js';
 
 const PROFILES_FILE = 'profiles.json';
 
@@ -27,7 +28,12 @@ function getProfilesPath(): string {
 export async function loadProfiles(): Promise<ProfileConfig> {
   const profilesPath = getProfilesPath();
   if (await fs.pathExists(profilesPath)) {
-    return await fs.readJson(profilesPath);
+    const config: ProfileConfig = await fs.readJson(profilesPath);
+    // Expand ~ to absolute paths for runtime use
+    for (const profile of Object.values(config.profiles)) {
+      profile.configDir = expandPath(profile.configDir);
+    }
+    return config;
   }
   return { profiles: {} };
 }
@@ -35,7 +41,16 @@ export async function loadProfiles(): Promise<ProfileConfig> {
 export async function saveProfiles(config: ProfileConfig): Promise<void> {
   const profilesPath = getProfilesPath();
   const tmpPath = `${profilesPath}.${process.pid}.tmp`;
-  await fs.writeJson(tmpPath, config, { spaces: 2 });
+  // Store paths with ~ for portability across machines
+  const portableConfig: ProfileConfig = {
+    profiles: Object.fromEntries(
+      Object.entries(config.profiles).map(([name, profile]) => [
+        name,
+        { ...profile, configDir: formatPath(profile.configDir) },
+      ])
+    ),
+  };
+  await fs.writeJson(tmpPath, portableConfig, { spaces: 2 });
   await fs.rename(tmpPath, profilesPath);
 }
 

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -3,8 +3,7 @@ import path from 'path';
 import crypto from 'crypto';
 import os from 'os';
 import type { FileMapping, SyncResult, MetaJson } from '../types/index.js';
-import { getConfigPaths } from './paths.js';
-import { expandPath, formatPath } from '../utils/logger.js';
+import { getConfigPaths, expandPath, contractPath } from './paths.js';
 
 export const FILE_MAPPINGS: FileMapping[] = [
   {
@@ -263,7 +262,7 @@ export function createMetaJson(claudeConfigPath: string): MetaJson {
     lastSync: null,
     machineId: `${hostname}-${machineId}`,
     platform,
-    claudeConfigPath: formatPath(claudeConfigPath),
+    claudeConfigPath,
   };
 }
 
@@ -286,7 +285,8 @@ export async function writeMetaJson(
   meta: MetaJson
 ): Promise<void> {
   const metaPath = path.join(jeanClaudeDir, 'meta.json');
-  const portableMeta = { ...meta, claudeConfigPath: formatPath(meta.claudeConfigPath) };
+  // Store the path with ~ so meta.json stays portable across machines
+  const portableMeta = { ...meta, claudeConfigPath: contractPath(meta.claudeConfigPath) };
   await fs.writeJson(metaPath, portableMeta, { spaces: 2 });
 }
 

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import os from 'os';
 import type { FileMapping, SyncResult, MetaJson } from '../types/index.js';
 import { getConfigPaths } from './paths.js';
+import { expandPath, formatPath } from '../utils/logger.js';
 
 export const FILE_MAPPINGS: FileMapping[] = [
   {
@@ -262,7 +263,7 @@ export function createMetaJson(claudeConfigPath: string): MetaJson {
     lastSync: null,
     machineId: `${hostname}-${machineId}`,
     platform,
-    claudeConfigPath,
+    claudeConfigPath: formatPath(claudeConfigPath),
   };
 }
 
@@ -272,7 +273,9 @@ export async function readMetaJson(jeanClaudeDir: string): Promise<MetaJson | nu
     return null;
   }
   try {
-    return await fs.readJson(metaPath);
+    const meta: MetaJson = await fs.readJson(metaPath);
+    meta.claudeConfigPath = expandPath(meta.claudeConfigPath);
+    return meta;
   } catch {
     return null;
   }
@@ -283,7 +286,8 @@ export async function writeMetaJson(
   meta: MetaJson
 ): Promise<void> {
   const metaPath = path.join(jeanClaudeDir, 'meta.json');
-  await fs.writeJson(metaPath, meta, { spaces: 2 });
+  const portableMeta = { ...meta, claudeConfigPath: formatPath(meta.claudeConfigPath) };
+  await fs.writeJson(metaPath, portableMeta, { spaces: 2 });
 }
 
 export async function updateLastSync(jeanClaudeDir: string): Promise<void> {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,6 @@
 import chalk from 'chalk';
+import os from 'os';
+import path from 'path';
 
 const orange = chalk.hex('#FF6B4A');
 
@@ -51,6 +53,17 @@ export function formatPath(p: string): string {
   const home = process.env.HOME || '';
   if (home && p.startsWith(home)) {
     return '~' + p.slice(home.length);
+  }
+  return p;
+}
+
+/**
+ * Expand a leading ~ to the user's home directory.
+ * Enables portable paths in config files across machines.
+ */
+export function expandPath(p: string): string {
+  if (p.startsWith('~/') || p === '~') {
+    return path.join(os.homedir(), p.slice(1));
   }
   return p;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
-import os from 'os';
-import path from 'path';
+import { contractPath } from '../lib/paths.js';
 
 const orange = chalk.hex('#FF6B4A');
 
@@ -50,20 +49,5 @@ export const logger = {
 };
 
 export function formatPath(p: string): string {
-  const home = process.env.HOME || '';
-  if (home && p.startsWith(home)) {
-    return '~' + p.slice(home.length);
-  }
-  return p;
-}
-
-/**
- * Expand a leading ~ to the user's home directory.
- * Enables portable paths in config files across machines.
- */
-export function expandPath(p: string): string {
-  if (p.startsWith('~/') || p === '~') {
-    return path.join(os.homedir(), p.slice(1));
-  }
-  return p;
+  return contractPath(p);
 }

--- a/tests/unit/lib/paths.test.ts
+++ b/tests/unit/lib/paths.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'os';
+import { expandPath, contractPath } from '../../../src/lib/paths.js';
+
+describe('paths.ts', () => {
+  const home = '/Users/testuser';
+
+  beforeEach(() => {
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('expandPath', () => {
+    it('should expand ~/ to the home directory', () => {
+      expect(expandPath('~/.claude-work')).toBe('/Users/testuser/.claude-work');
+      expect(expandPath('~/a/b/c')).toBe('/Users/testuser/a/b/c');
+    });
+
+    it('should expand a bare ~ to the home directory', () => {
+      expect(expandPath('~')).toBe(home);
+    });
+
+    it('should pass through absolute paths unchanged', () => {
+      expect(expandPath('/var/log/test.log')).toBe('/var/log/test.log');
+      expect(expandPath(home)).toBe(home);
+    });
+
+    it('should not expand ~username-style paths', () => {
+      expect(expandPath('~other/dir')).toBe('~other/dir');
+    });
+
+    it('should pass through falsy input unchanged', () => {
+      expect(expandPath('')).toBe('');
+      // Old meta.json files may lack claudeConfigPath entirely
+      expect(expandPath(undefined as unknown as string)).toBeUndefined();
+    });
+
+    it('should be idempotent', () => {
+      const expanded = expandPath('~/.claude-work');
+      expect(expandPath(expanded)).toBe(expanded);
+    });
+  });
+
+  describe('contractPath', () => {
+    it('should replace the home directory prefix with ~', () => {
+      expect(contractPath('/Users/testuser/.claude-work')).toBe('~/.claude-work');
+    });
+
+    it('should contract an exact home directory match to ~', () => {
+      expect(contractPath(home)).toBe('~');
+    });
+
+    it('should not contract sibling directories sharing the home prefix', () => {
+      // /Users/testusershared starts with the home string but is a different dir;
+      // contracting it to ~shared/... would not survive expandPath.
+      expect(contractPath('/Users/testusershared/x')).toBe('/Users/testusershared/x');
+    });
+
+    it('should pass through paths outside the home directory', () => {
+      expect(contractPath('/var/log/test.log')).toBe('/var/log/test.log');
+    });
+
+    it('should pass through falsy input unchanged', () => {
+      expect(contractPath('')).toBe('');
+    });
+
+    it('should be idempotent', () => {
+      const contracted = contractPath('/Users/testuser/.claude-work');
+      expect(contractPath(contracted)).toBe(contracted);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('should restore the original absolute path', () => {
+      const paths = [
+        '/Users/testuser/.claude-work',
+        home,
+        '/Users/testusershared/x',
+        '/var/log/test.log',
+      ];
+      for (const p of paths) {
+        expect(expandPath(contractPath(p))).toBe(p);
+      }
+    });
+  });
+});

--- a/tests/unit/lib/profiles.test.ts
+++ b/tests/unit/lib/profiles.test.ts
@@ -3,11 +3,16 @@ import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
 
-// Mock paths module before importing profiles
-vi.mock('../../../src/lib/paths.js', () => ({
-  getConfigPaths: vi.fn(),
-  getJeanClaudeDir: vi.fn(),
-}));
+// Mock paths module before importing profiles.
+// Keep the real expandPath/contractPath so path round-tripping works in tests.
+vi.mock('../../../src/lib/paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/lib/paths.js')>();
+  return {
+    ...actual,
+    getConfigPaths: vi.fn(),
+    getJeanClaudeDir: vi.fn(),
+  };
+});
 
 import {
   createProfile,
@@ -212,6 +217,39 @@ describe('profiles.ts', () => {
       const files = await fs.readdir(jcDir);
       const tmpFiles = files.filter(f => f.endsWith('.tmp'));
       expect(tmpFiles).toEqual([]);
+    });
+  });
+
+  describe('saveProfiles/loadProfiles — portable ~ paths', () => {
+    it('should store configDir with ~ on disk and expand it on load', async () => {
+      // os.homedir() is mocked to tempDir in beforeEach
+      const configDir = path.join(tempDir, '.claude-work');
+      await saveProfiles({
+        profiles: { work: { alias: 'claude-work', configDir } },
+      });
+
+      const raw = await fs.readJson(path.join(jeanClaudeDir, 'profiles.json'));
+      expect(raw.profiles.work.configDir).toBe('~/.claude-work');
+
+      const loaded = await loadProfiles();
+      expect(loaded.profiles.work.configDir).toBe(configDir);
+    });
+
+    it('should not mutate the config object passed to saveProfiles', async () => {
+      const configDir = path.join(tempDir, '.claude-work');
+      const config = { profiles: { work: { alias: 'claude-work', configDir } } };
+
+      await saveProfiles(config);
+      expect(config.profiles.work.configDir).toBe(configDir);
+    });
+
+    it('should load legacy profiles.json with absolute paths unchanged', async () => {
+      await fs.writeJson(path.join(jeanClaudeDir, 'profiles.json'), {
+        profiles: { old: { alias: 'claude-old', configDir: '/tmp/absolute-dir' } },
+      });
+
+      const loaded = await loadProfiles();
+      expect(loaded.profiles.old.configDir).toBe('/tmp/absolute-dir');
     });
   });
 

--- a/tests/unit/lib/sync.test.ts
+++ b/tests/unit/lib/sync.test.ts
@@ -131,6 +131,39 @@ describe('sync.ts', () => {
         const meta = await readMetaJson(jeanClaudeDir);
         expect(meta).toBeNull();
       });
+
+      it('should store claudeConfigPath with ~ on disk and expand it on read', async () => {
+        const claudeConfigPath = path.join(os.homedir(), '.claude');
+        const meta = createMetaJson(claudeConfigPath);
+        const jeanClaudeDir = path.join(tempDir, '.jean-claude');
+        await fs.ensureDir(jeanClaudeDir);
+
+        // createMetaJson keeps the runtime value absolute
+        expect(meta.claudeConfigPath).toBe(claudeConfigPath);
+
+        await writeMetaJson(jeanClaudeDir, meta);
+
+        const raw = await fs.readJson(path.join(jeanClaudeDir, 'meta.json'));
+        expect(raw.claudeConfigPath).toBe('~/.claude');
+
+        const readMeta = await readMetaJson(jeanClaudeDir);
+        expect(readMeta!.claudeConfigPath).toBe(claudeConfigPath);
+      });
+
+      it('should tolerate legacy meta.json without claudeConfigPath', async () => {
+        const jeanClaudeDir = path.join(tempDir, '.jean-claude');
+        await fs.ensureDir(jeanClaudeDir);
+        await fs.writeJson(path.join(jeanClaudeDir, 'meta.json'), {
+          version: '1.0.0',
+          lastSync: null,
+          machineId: 'host-abc123',
+          platform: 'darwin',
+        });
+
+        const meta = await readMetaJson(jeanClaudeDir);
+        expect(meta).not.toBeNull();
+        expect(meta!.claudeConfigPath).toBeUndefined();
+      });
     });
 
     describe('updateLastSync', () => {


### PR DESCRIPTION
Continues #66 by @xfab-roy — the original commit is preserved for attribution, with the review follow-ups applied on top.

## What this adds on top of #66

**Review follow-ups from the maintainer:**
- Both helpers now use `os.homedir()` (previously `formatPath` read `process.env.HOME`, so an unset `HOME` silently persisted absolute paths)
- Falsy-input guard, so a legacy `meta.json` without `claudeConfigPath` no longer throws on `.startsWith`
- Unit tests for the helpers

**Additional fixes found in review:**
- **Boundary bug**: `formatPath` contracted any path merely *starting with* the home string — `/Users/mikeshared/x` was persisted as `~shared/x`, which never expands back. Contraction now only happens at a path boundary (`p === home || p.startsWith(home + path.sep)`), with a regression test.
- **Dedicated serialization helpers**: `expandPath`/`contractPath` now live in `src/lib/paths.ts`; the display helper `logger.formatPath` delegates to `contractPath`. Config persistence no longer piggybacks on a display formatter that could be tweaked independently.
- `createMetaJson` keeps its runtime value absolute; contraction happens only at the write boundary (`writeMetaJson`), symmetric with expansion in `readMetaJson`.

## Tests

- New `tests/unit/lib/paths.test.ts`: expansion, contraction, boundary/sibling-dir case, falsy input, idempotency, round-trips
- `profiles.json` round-trip: stored with `~`, loaded absolute, input config not mutated, legacy absolute paths still load
- `meta.json` round-trip plus tolerance for legacy files missing `claudeConfigPath`
- 79 unit + 186 integration tests pass

## Notes

- No version bump here; this changes the on-disk config format (older jean-claude versions read `~` paths literally), so it should ship in a minor release (2.1.0) via the usual release branch.
- Windows note for #71: with `os.homedir()` this now behaves sensibly on Windows too, though `~` contraction there only matters once #71 lands.

Closes #66. Thanks @xfab-roy for the original implementation!
