### PR TITLE
test: add trailing-slash and relative-path coverage for contractPath

### DIFF
--- a/tests/unit/lib/paths.test.ts
+++ b/tests/unit/lib/paths.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import os from 'os';
+import path from 'path';
 import { expandPath, contractPath } from '../../../src/lib/paths.js';
 
 describe('paths.ts', () => {
@@ -65,6 +66,18 @@ describe('paths.ts', () => {
 
     it('should pass through falsy input unchanged', () => {
       expect(contractPath('')).toBe('');
+    });
+
+    it('should handle paths with trailing separators', () => {
+      const trailing = home + '/documents/folder' + path.sep;
+      const contracted = contractPath(trailing);
+      expect(contracted.startsWith('~')).toBe(true);
+      expect(expandPath(contracted)).toBe(trailing);
+    });
+
+    it('should pass through relative paths unchanged', () => {
+      expect(contractPath('./relative/path')).toBe('./relative/path');
+      expect(contractPath('../sibling/file.txt')).toBe('../sibling/file.txt');
     });
 
     it('should be idempotent', () => {


### PR DESCRIPTION
## Summary

Follow-up to #76. The reviewer flagged that `paths.test.ts` didn't have full parity with the deleted `logger.test.ts`.

This adds the two missing edge-case tests:

- **Trailing slashes** — verifies `contractPath` handles trailing separators and round-trips correctly
- **Relative paths** — verifies `contractPath` passes relative paths (./foo, ../bar) through unchanged

These two cases were covered in the deleted `tests/unit/utils/logger.test.ts` but weren't in `paths.test.ts`. All other edge cases were already covered.