### PR TITLE
feat: add fish shell support for profile aliases

### DIFF
--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -255,7 +255,7 @@ export async function handleProfileDelete(
 
   // Remove shell alias
   logger.step(2, 2, 'Cleaning up shell aliases...');
-  const shellFiles = ['.zshrc', '.bashrc', '.bash_profile'];
+  const shellFiles = ['.zshrc', '.bashrc', '.bash_profile', '.config/fish/config.fish'];
   for (const shellFile of shellFiles) {
     const removed = await removeShellAlias(name, shellFile);
     if (removed) {

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -272,6 +272,10 @@ export function detectShellConfigFiles(): Array<{ name: string; value: string }>
   if (fs.existsSync(path.join(home, '.bash_profile'))) {
     options.push({ name: '.bash_profile (bash)', value: '.bash_profile' });
   }
+  const fishConfig = path.join(home, '.config/fish/config.fish');
+  if (fs.existsSync(fishConfig)) {
+    options.push({ name: '.config/fish/config.fish (fish)', value: '.config/fish/config.fish' });
+  }
 
   // Always offer these even if they don't exist yet
   if (!options.some((o) => o.value === '.zshrc')) {
@@ -282,6 +286,9 @@ export function detectShellConfigFiles(): Array<{ name: string; value: string }>
       name: '.bashrc (bash) - will be created',
       value: '.bashrc',
     });
+  }
+  if (!options.some((o) => o.value === '.config/fish/config.fish')) {
+    options.push({ name: '.config/fish/config.fish (fish) - will be created', value: '.config/fish/config.fish' });
   }
 
   return options;

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -235,7 +235,8 @@ export async function installShellAlias(
     }
   }
 
-  // Append alias block
+  // Append alias block (fish config lives in ~/.config/fish, which may not exist yet)
+  await fs.ensureFile(rcPath);
   await fs.appendFile(rcPath, block);
 }
 

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -2004,6 +2004,7 @@ run_all_tests() {
     test_profile_no_share_statusline
     test_profile_share_both
     test_profile_shell_alias
+    test_profile_shell_alias_fish
     test_profile_list
     test_profile_create_second
     test_profile_create_duplicate

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -1181,6 +1181,17 @@ test_profile_shell_alias() {
     assert_file_contains "$MACHINE1_DIR/.zshrc" "CLAUDE_CONFIG_DIR"
 }
 
+test_profile_shell_alias_fish() {
+    print_test "profile shell alias installation for fish"
+
+    run_jean_claude "$MACHINE1_DIR" profile create fish-alias --yes --shell .config/fish/config.fish
+
+    assert_file_exists "$MACHINE1_DIR/.config/fish/config.fish"
+    assert_file_contains "$MACHINE1_DIR/.config/fish/config.fish" "jean-claude profile: fish-alias"
+    assert_file_contains "$MACHINE1_DIR/.config/fish/config.fish" "claude-fish-alias"
+    assert_file_contains "$MACHINE1_DIR/.config/fish/config.fish" "CLAUDE_CONFIG_DIR"
+}
+
 test_profile_list() {
     print_test "profile list command"
 

--- a/tests/unit/lib/profiles.test.ts
+++ b/tests/unit/lib/profiles.test.ts
@@ -22,6 +22,7 @@ import {
   installShellAlias,
   removeShellAlias,
   getShellAliasLine,
+  detectShellConfigFiles,
   SHARED_ITEMS,
 } from '../../../src/lib/profiles.js';
 import { getConfigPaths, getJeanClaudeDir } from '../../../src/lib/paths.js';
@@ -325,6 +326,22 @@ describe('profiles.ts', () => {
       // Don't create any shared items
       const created = await createSymlinks(sourceDir, targetDir);
       expect(created).toEqual([]);
+    });
+  });
+
+  describe('detectShellConfigFiles', () => {
+    it('should detect fish config file when it exists', async () => {
+      const fishConfig = path.join(tempDir, '.config/fish/config.fish');
+      await fs.ensureFile(fishConfig);
+
+      const options = detectShellConfigFiles();
+      expect(options.some((o) => o.value === '.config/fish/config.fish')).toBe(true);
+    });
+
+    it('should always offer fish config even if it does not exist', async () => {
+      const options = detectShellConfigFiles();
+      expect(options.some((o) => o.value === '.config/fish/config.fish')).toBe(true);
+      expect(options.find((o) => o.value === '.config/fish/config.fish')?.name).toContain('will be created');
     });
   });
 });

--- a/tests/unit/lib/profiles.test.ts
+++ b/tests/unit/lib/profiles.test.ts
@@ -276,6 +276,20 @@ describe('profiles.ts', () => {
       expect(content2).toContain('/updated/path');
     });
 
+    it('should create missing parent directories (fish config)', async () => {
+      const profile = { alias: 'claude-fishy', configDir: path.join(tempDir, '.claude-fishy') };
+
+      // ~/.config/fish does not exist yet
+      await installShellAlias('fishy', profile, '.config/fish/config.fish');
+
+      const content = await fs.readFile(
+        path.join(tempDir, '.config/fish/config.fish'),
+        'utf-8'
+      );
+      expect(content).toContain('jean-claude profile: fishy');
+      expect(content).toContain('claude-fishy');
+    });
+
     it('should not match other profile names when replacing', async () => {
       const rcPath = path.join(tempDir, '.zshrc');
       const profileA = { alias: 'claude-a', configDir: path.join(tempDir, '.claude-a') };
@@ -335,7 +349,10 @@ describe('profiles.ts', () => {
       await fs.ensureFile(fishConfig);
 
       const options = detectShellConfigFiles();
-      expect(options.some((o) => o.value === '.config/fish/config.fish')).toBe(true);
+      const fishOption = options.find((o) => o.value === '.config/fish/config.fish');
+      expect(fishOption).toBeDefined();
+      // Detected as existing, not offered via the "will be created" fallback
+      expect(fishOption?.name).not.toContain('will be created');
     });
 
     it('should always offer fish config even if it does not exist', async () => {


### PR DESCRIPTION
## Summary

Add fish shell support to jean-claude profile shell aliases, addressing [#74](https://github.com/MikeVeerman/jean-claude/issues/74).

## Changes

- `src/lib/profiles.ts`: Detect `.config/fish/config.fish` in `detectShellConfigFiles()`
- `src/commands/profile.ts`: Clean up fish config on profile delete
- `tests/unit/lib/profiles.test.ts\): Add unit tests for fish detection
- `test-integration.sh\): Add integration test for fish alias installation

## Notes

The existing alias syntax `alias claude-work='CLAUDE_CONFIG_DIR="..." claude'` works in fish as-is — no syntax changes needed.
